### PR TITLE
MPD-7655: added android support

### DIFF
--- a/meili_flutter/README.md
+++ b/meili_flutter/README.md
@@ -2,149 +2,240 @@
 
 [![pub package](https://img.shields.io/pub/v/meili_flutter.svg)](https://pub.dev/packages/meili_flutter)
 
-The Meili Flutter Plugin allows you to integrate the Meili experience into your Flutter applications.
+The Meili Flutter Plugin allows you to integrate the Meili car rental experience into your Flutter applications on both iOS and Android.
 
-## Features
+## Overview
 
-**Cross-Platform Support**: The Meili plugin supports both iOS and Android platforms.
+`meili_flutter` is a federated Flutter plugin that wraps the native Meili UX SDKs:
 
-**Customizable UI**: Provides powerful and customizable UI screens and elements to collect user details.
+- **Android** native SDK: hosted as a Maven artifact on GitHub Packages at `meili-travel-tech/ux-native-android-sdk` (requires auth).
+- **iOS** native SDK: distributed as a CocoaPod (`MeiliSDK`) via a private spec repo at `meili-travel-tech/meili-ios-pods` (requires SSH/HTTPS access).
 
-**Direct Integration**: Directly integrates with Meili for a seamless user experience.
+---
 
-**Platform Specific Implementation**: Different implementations for iOS and Android, ensuring optimal performance on each platform.
+## Prerequisites
 
-## Installation
+| Requirement | Why |
+|---|---|
+| Flutter SDK `>=3.4.0` | Minimum required by the plugin. |
+| Android Studio / Xcode CLI tools | Needed for native builds. |
+| CocoaPods (`gem install cocoapods`) | iOS dependency manager. |
+| GitHub Personal Access Token with `read:packages` scope | Downloads the Android AAR from GitHub Packages. |
+| Membership in the `meili-travel-tech` GitHub org | Both the iOS spec repo and Android Maven artifacts are under this org. Contact Meili to get access. |
 
-Add the following to your `pubspec.yaml` file:
+---
+
+## 1. Dart / pubspec setup
 
 ```yaml
 dependencies:
-    meili_flutter: ^1.0.0
+  meili_flutter: 0.3.1-beta.1
 ```
 
-Run `flutter pub get` to install the package.
+```bash
+flutter pub get
+```
 
-### Requirements
+This resolves the federated sub-packages automatically — you do not need to add `meili_flutter_android` or `meili_flutter_ios` manually.
 
--   iOS Version: 16.0 or higher
--   Android Version: As per your project's minimum SDK requirements
+---
 
-#### iOS
+## 2. Android setup
 
-Compatible with apps targeting iOS 16 or above.
+### 2.1 GitHub credentials
 
-Update your iOS deployment target to 13.0 in your `project.pbxproj` or via Xcode under Build Settings.
+The Android SDK is hosted on a private GitHub Packages repo. Set these environment variables before building:
 
-Update your `Podfile`:
+```bash
+export MEILI_GITHUB_USERNAME="your-github-username"
+export MEILI_GITHUB_TOKEN="ghp_xxxxxxxxxxxxxxxxxxxx"
+```
+
+**Where to put them:**
+- CLI builds (`flutter run` in Terminal): append to `~/.zshrc`
+- IDE / GUI app builds (Android Studio, VS Code launched from Finder): append to `~/.zshenv` — GUI apps on macOS don't always source `~/.zshrc`
+
+After editing, reload with `source ~/.zshenv` or open a new terminal.
+
+**Verifying:**
+```bash
+echo "${MEILI_GITHUB_USERNAME:-NOT_SET}"
+[ -n "$MEILI_GITHUB_TOKEN" ] && echo "TOKEN_SET" || echo "TOKEN_NOT_SET"
+```
+
+**Failure mode:** if credentials are missing you will see:
+```
+Could not resolve meili.travel:ux-native-android-sdk:...
+  > Received status code 401 from server: Unauthorized
+```
+
+### 2.2 `android/build.gradle.kts` — declare the Maven repo
+
+```kotlin
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+        maven {
+            url = uri("https://maven.pkg.github.com/meili-travel-tech/ux-native-android-sdk")
+            credentials {
+                username = System.getenv("MEILI_GITHUB_USERNAME") ?: ""
+                password = System.getenv("MEILI_GITHUB_TOKEN") ?: ""
+            }
+        }
+    }
+}
+```
+
+### 2.3 `android/app/build.gradle.kts` — NDK + minSdk
+
+```kotlin
+android {
+    ndkVersion = "27.0.12077973"
+    defaultConfig {
+        minSdk = 27
+    }
+}
+```
+
+- `ndkVersion` must be pinned exactly — using `flutter.ndkVersion` may cause a linker error.
+- `minSdk = 27` is required by the Meili Android SDK.
+
+### 2.4 `android/settings.gradle.kts` — Kotlin Compose plugin
+
+```kotlin
+plugins {
+    id("dev.flutter.flutter-plugin-loader") version "1.0.0"
+    id("com.android.application") version "8.7.3" apply false
+    id("org.jetbrains.kotlin.android") version "2.1.0" apply false
+    id("org.jetbrains.kotlin.plugin.compose") version "2.1.0" apply false  // add this
+}
+```
+
+### 2.5 `MainActivity.kt`
+
+```kotlin
+import io.flutter.embedding.android.FlutterFragmentActivity
+
+class MainActivity : FlutterFragmentActivity()
+```
+
+> If you leave `FlutterActivity` here you will get an `IllegalStateException` at runtime when opening the Meili view.
+
+---
+
+## 3. iOS setup
+
+### 3.1 `ios/Podfile`
 
 ```ruby
-source 'https://github.com/meili-travel-tech/meili-ios-pods'
-
 platform :ios, '16.0'
+
+source 'https://cdn.cocoapods.org/'
+source 'git@github.com:meili-travel-tech/meili-ios-pods.git'
+
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+# ... rest of the standard Flutter Podfile unchanged
 ```
 
-## Usage
+> If you use a multi-account SSH setup, replace `git@github.com:` with your Host alias e.g. `git@github.com-meili:`.
 
-### Card payments
+### 3.2 iOS deployment target
 
-There are 3 ways of handling card payments
+Set `IPHONEOS_DEPLOYMENT_TARGET = 16.0` in three places in `ios/Runner.xcodeproj/project.pbxproj` (Debug, Release, Profile), or via Xcode under **Runner target → General → Minimum Deployments → iOS**.
 
-| Method               | Ease of use | description                                                            | Implementation docs                                                                           |
-| -------------------- | ----------- | ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| Meili Sheet View     | Easy        | It opens a sheet view screen rendering the Meili Flow                  | [Meili Support](https://meili.atlassian.net/servicedesk/customer/portal/1/article/1304231937) |
-| Meili Connect Widget | Easy        | Native flutter widget to be embedded together any other flutter widget | [Meili Support](https://meili.atlassian.net/servicedesk/customer/portal/1/article/1304231937) |
+### 3.3 `ios/Flutter/AppFrameworkInfo.plist`
 
-#### Meili Direct
+```xml
+<key>MinimumOSVersion</key>
+<string>16.0</string>
+```
 
-To open the Meili view for the direct flow, use the following code snippet:
+### 3.4 Install pods
+
+```bash
+cd ios && pod install --repo-update && cd ..
+```
+
+`--repo-update` is needed the first time to clone the private spec repo. Plain `pod install` is sufficient on subsequent runs.
+
+---
+
+## 4. Usage
+
+### Embedded widget
 
 ```dart
 import 'package:meili_flutter/meili_flutter.dart';
 
-void _openMeiliView() async {
-    final params = MeiliParams(
-      ptid: 'ptid',
-      currentFlow: FlowType.direct,
-      env: 'dev',
-    );
-
-    try {
-      await Meili.openMeiliView(params);
-    } catch (e) {
-      print("Failed to open MeiliView: $e");
-    }
-  }
-```
-
-#### Meili Booking Manager
-
-To open the Meili view for the direct flow, use the following code snippet:
-
-```dart
-import 'package:meili_flutter/meili_flutter.dart';
-
-void _openMeiliView() async {
-    final params = MeiliParams(
-      ptid: 'ptid',
-      currentFlow: FlowType.bookingManager,
-      env: 'dev',
-      // you can pass the values to prefill the fields
-      // it will search automatically once the flow is opened
-      bookingParams: BookingParams(
-        confirmationId: "1234ABCD",
-        lastName: "Doe"
-      )
-
-    );
-
-    try {
-      await Meili.openMeiliView(params);
-    } catch (e) {
-      print("Failed to open MeiliView: $e");
-    }
-  }
-```
-
-#### Meili Connect
-
-To use the MeiliConnectWidget, integrate it into your widget tree with the necessary parameters:
-
-```dart
-import 'package:flutter/material.dart';
-import 'package:meili_flutter/meili_flutter.dart';
-
-MeiliConnectWidget(
-  ptid: '100.10',
-  env: 'dev',
+MeiliView(
+  ptid: 'your-ptid',
+  env: 'prod',               // 'dev', 'uat', 'pre_prod', 'prod'
+  currentFlow: FlowType.direct,
   availParams: AvailParams(
-    pickupLocation: 'BCN',
-    dropoffLocation: 'BCN',
-    pickupDate: '2025-01-01',
-    pickupTime: '12:00',
-    dropoffDate: '2025-01-07',
-    dropoffTime: '12:00',
-    driverAge: 25,
-    currencyCode: 'EUR',
-    residency: 'IE',
-  )
-);
+    pickupLocation: 'DXB',
+    dropoffLocation: 'DXB',
+    pickupDate: '2025-06-01',
+    pickupTime: '10:00',
+    dropoffDate: '2025-06-05',
+    dropoffTime: '10:00',
+    driverAge: 30,
+    currencyCode: 'USD',
+    residency: 'US',
+  ),
+)
 ```
 
-## Error Handling
+### Full-screen modal
 
-If an error occurs while attempting to open the Meili view, a `PlatformException` will be thrown, and an error message will be printed to the console.
+```dart
+import 'package:meili_flutter/meili_flutter.dart';
+
+await Meili.openMeiliView(MeiliParams(
+  ptid: 'your-ptid',
+  env: 'prod',
+  flow: FlowType.direct,
+));
+```
+
+### Booking Manager
+
+```dart
+await Meili.openMeiliView(MeiliParams(
+  ptid: 'your-ptid',
+  env: 'prod',
+  flow: FlowType.bookingManager,
+  additionalParams: AdditionalParams(
+    confirmationId: '1234ABCD',
+    lastName: 'Doe',
+  ),
+));
+```
+
+---
+
+## 5. Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `401 Unauthorized` resolving Maven dep | `MEILI_GITHUB_TOKEN` missing or lacks `read:packages` scope | Re-create PAT with `read:packages`, export, restart shell. |
+| `Could not find ... .aar` during Gradle | Maven repo URL or token missing | Check `build.gradle.kts` repo block and env vars. |
+| `Unable to find a specification for MeiliSDK` | Missing `source` line in Podfile | Add the private spec repo URL. |
+| `pod install` hangs on first run | First-time SSH clone of spec repo | Confirm SSH key: `ssh -T git@github.com`. |
+| `IllegalStateException ... requires FragmentActivity` | `MainActivity` still extends `FlutterActivity` | Change to `FlutterFragmentActivity`. |
+| NDK strip / linker errors | NDK version mismatch | Pin `ndkVersion = "27.0.12077973"`. |
+| Env vars set in terminal but not in Android Studio | macOS GUI apps don't load `~/.zshrc` | Move env vars to `~/.zshenv`, relaunch Android Studio. |
+
+---
 
 ## Platform Support
 
-### iOS
-
-The Meili view is supported on iOS. The `MethodChannel` for iOS is `meili_flutter_ios`.
-
-### Android
-
-We are working to integrate the Meili Android SDK into the Meili Flutter plugin. Support for the Meili view on Android will be available very soon. In the meantime, attempting to open the Meili view on Android may result in a PlatformException with the message "Android platform view is not yet supported".
+| Platform | Supported |
+|---|---|
+| Android | ✅ |
+| iOS | ✅ |
 
 ## Contributing
 
-You can help us make this project better by opening new issues or pull requests.
+Open issues or pull requests at [github.com/meili-travel-tech/flutter_meili](https://github.com/meili-travel-tech/flutter_meili).

--- a/meili_flutter/example/android/app/build.gradle
+++ b/meili_flutter/example/android/app/build.gradle
@@ -1,32 +1,12 @@
-def localProperties = new Properties()
-def localPropertiesFile = rootProject.file('local.properties')
-if (localPropertiesFile.exists()) {
-    localPropertiesFile.withReader('UTF-8') { reader ->
-        localProperties.load(reader)
-    }
+plugins {
+    id "com.android.application"
+    id "kotlin-android"
+    id "dev.flutter.flutter-gradle-plugin"
 }
-
-def flutterRoot = localProperties.getProperty('flutter.sdk')
-if (flutterRoot == null) {
-    throw new GradleException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
-}
-
-def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
-if (flutterVersionCode == null) {
-    flutterVersionCode = '1'
-}
-
-def flutterVersionName = localProperties.getProperty('flutter.versionName')
-if (flutterVersionName == null) {
-    flutterVersionName = '1.0'
-}
-
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion flutter.compileSdkVersion
+    namespace "com.flutter.meili.example"
+    compileSdk flutter.compileSdkVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -34,35 +14,30 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = "1.8"
     }
 
     sourceSets {
-        main.java.srcDirs += 'src/main/kotlin'
+        main.java.srcDirs += "src/main/kotlin"
     }
 
+    ndkVersion "26.3.11579264"
+
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.flutter.meili.example"
-        minSdkVersion flutter.minSdkVersion
-        targetSdkVersion flutter.targetSdkVersion
-        versionCode flutterVersionCode.toInteger()
-        versionName flutterVersionName
+        minSdk 27
+        targetSdk flutter.targetSdkVersion
+        versionCode flutter.versionCode
+        versionName flutter.versionName
     }
 
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig signingConfigs.debug
         }
     }
 }
 
 flutter {
-    source '../..'
-}
-
-dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    source "../.."
 }

--- a/meili_flutter/example/android/app/src/main/kotlin/com/flutter/meili/example/MainActivity.kt
+++ b/meili_flutter/example/android/app/src/main/kotlin/com/flutter/meili/example/MainActivity.kt
@@ -1,6 +1,6 @@
 package com.flutter.meili.example
 
-import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.android.FlutterFragmentActivity
 
-class MainActivity: FlutterActivity() {
+class MainActivity: FlutterFragmentActivity() {
 }

--- a/meili_flutter/example/android/build.gradle
+++ b/meili_flutter/example/android/build.gradle
@@ -1,31 +1,23 @@
-buildscript {
-    ext.kotlin_version = '1.6.10'
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
-}
-
-rootProject.buildDir = '../build'
+rootProject.buildDir = "../build"
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
 }
 subprojects {
-    project.evaluationDependsOn(':app')
+    project.evaluationDependsOn(":app")
 }
 
-task clean(type: Delete) {
-    delete rootProject.buildDir
+allprojects {
+    repositories {
+        maven {
+            url = uri("https://maven.pkg.github.com/meili-travel-tech/ux-native-android-sdk")
+            credentials {
+                username = System.getenv("MEILI_GITHUB_USERNAME") ?: ""
+                password = System.getenv("MEILI_GITHUB_TOKEN") ?: ""
+            }
+        }
+    }
+}
+
+tasks.register("clean", Delete) {
+    delete rootProject.layout.buildDirectory
 }

--- a/meili_flutter/example/android/gradle.properties
+++ b/meili_flutter/example/android/gradle.properties
@@ -1,3 +1,3 @@
-org.gradle.jvmargs=-Xmx1536M
+org.gradle.jvmargs=-Xmx4096M
 android.useAndroidX=true
 android.enableJetifier=true

--- a/meili_flutter/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/meili_flutter/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Fri Jun 23 08:50:38 CEST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip

--- a/meili_flutter/example/android/settings.gradle
+++ b/meili_flutter/example/android/settings.gradle
@@ -1,11 +1,26 @@
-include ':app'
+pluginManagement {
+    def flutterSdkPath = {
+        def properties = new Properties()
+        file("local.properties").withInputStream { properties.load(it) }
+        def flutterSdkPath = properties.getProperty("flutter.sdk")
+        assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
+        return flutterSdkPath
+    }()
 
-def localPropertiesFile = new File(rootProject.projectDir, "local.properties")
-def properties = new Properties()
+    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
 
-assert localPropertiesFile.exists()
-localPropertiesFile.withReader("UTF-8") { reader -> properties.load(reader) }
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
 
-def flutterSdkPath = properties.getProperty("flutter.sdk")
-assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
-apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
+plugins {
+    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
+    id "com.android.application" version "8.3.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
+    id "org.jetbrains.kotlin.plugin.compose" version "2.1.0" apply false
+}
+
+include ":app"

--- a/meili_flutter/example/pubspec.yaml
+++ b/meili_flutter/example/pubspec.yaml
@@ -17,6 +17,10 @@ dependencies:
         # the parent directory to use the current plugin's version.
         path: ../
 
+dependency_overrides:
+    meili_flutter_android:
+        path: ../../meili_flutter_android
+
 dev_dependencies:
     flutter_driver:
         sdk: flutter

--- a/meili_flutter/lib/meili_flutter.dart
+++ b/meili_flutter/lib/meili_flutter.dart
@@ -6,3 +6,4 @@ export 'src/model/flow_enum.dart';
 export 'src/model/meili_params.dart';
 
 export 'src/widgets/connect.dart';
+export 'src/widgets/meili_view.dart';

--- a/meili_flutter/lib/src/meili.dart
+++ b/meili_flutter/lib/src/meili.dart
@@ -18,11 +18,9 @@ class Meili {
           params.toMap(),
         );
       } else if (defaultTargetPlatform == TargetPlatform.android) {
-        // Placeholder for Android until the native implementation is available
-
-        throw PlatformException(
-          code: 'UNSUPPORTED_PLATFORM',
-          message: 'Android platform view is not yet supported',
+        await _androidChannel.invokeMethod(
+          'openMeiliViewController',
+          params.toMap(),
         );
       } else {}
     } on PlatformException catch (e) {

--- a/meili_flutter/lib/src/widgets/meili_view.dart
+++ b/meili_flutter/lib/src/widgets/meili_view.dart
@@ -105,14 +105,24 @@ class _MethodChannelMeiliViewState extends State<_MethodChannelMeiliView> {
       'availParams': widget.availParams?.toMap(),
     };
 
-    final Widget platform = defaultTargetPlatform == TargetPlatform.iOS
-        ? UiKitView(
-            viewType: _viewType,
-            creationParams: creationParams,
-            creationParamsCodec: const StandardMessageCodec(),
-            onPlatformViewCreated: _onPlatformViewCreated,
-          )
-        : throw UnsupportedError('Unsupported platform view');
+    final Widget platform;
+    if (defaultTargetPlatform == TargetPlatform.iOS) {
+      platform = UiKitView(
+        viewType: _viewType,
+        creationParams: creationParams,
+        creationParamsCodec: const StandardMessageCodec(),
+        onPlatformViewCreated: _onPlatformViewCreated,
+      );
+    } else if (defaultTargetPlatform == TargetPlatform.android) {
+      platform = AndroidView(
+        viewType: _viewType,
+        creationParams: creationParams,
+        creationParamsCodec: const StandardMessageCodec(),
+        onPlatformViewCreated: _onPlatformViewCreated,
+      );
+    } else {
+      throw UnsupportedError('Unsupported platform view');
+    }
 
     final constraints = widget.constraints ??
         const BoxConstraints.expand(height: kViewDefaultHeight);

--- a/meili_flutter/pubspec.yaml
+++ b/meili_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: meili_flutter
 description: Meili Flutter plugin
-version: 0.3.0
+version: 0.3.1-beta.1
 
 homepage: https://github.com/meili-travel-tech/flutter_meili
 repository: https://github.com/meili-travel-tech/flutter_meili
@@ -21,7 +21,7 @@ flutter:
 dependencies:
     flutter:
         sdk: flutter
-    meili_flutter_android: ^0.1.1
+    meili_flutter_android: ^0.2.0-beta.2
     meili_flutter_ios: ^0.3.0
 
 dev_dependencies:

--- a/meili_flutter_android/android/build.gradle
+++ b/meili_flutter_android/android/build.gradle
@@ -2,14 +2,14 @@ group 'com.flutter.meili'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.7.10'
+    ext.kotlin_version = '2.1.0'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.0'
+        classpath 'com.android.tools.build:gradle:8.3.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -18,18 +18,26 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        maven {
+            url = uri("https://maven.pkg.github.com/meili-travel-tech/ux-native-android-sdk")
+            credentials {
+                username = System.getenv("MEILI_GITHUB_USERNAME") ?: ""
+                password = System.getenv("MEILI_GITHUB_TOKEN") ?: ""
+            }
+        }
     }
 }
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+apply plugin: 'org.jetbrains.kotlin.plugin.compose'
 
 android {
     if (project.android.hasProperty("namespace")) {
         namespace 'com.flutter.meili'
     }
 
-    compileSdk 34
+    compileSdk 35
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -46,12 +54,16 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 27
     }
 
-    dependencies {
-        testImplementation 'org.jetbrains.kotlin:kotlin-test'
-        testImplementation 'org.mockito:mockito-core:5.0.0'
+    buildFeatures {
+        compose true
+    }
+
+    packagingOptions {
+        pickFirst "**/libc++_shared.so"
+        pickFirst "**/libfbjni.so"
     }
 
     testOptions {
@@ -65,4 +77,17 @@ android {
             }
         }
     }
+}
+
+dependencies {
+    implementation "meili.travel:ux-native-android-sdk:1.1.0"
+
+    implementation 'androidx.activity:activity-compose:1.9.2'
+    implementation 'androidx.compose.ui:ui:1.7.2'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.8.6'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel:2.8.6'
+    implementation 'androidx.savedstate:savedstate:1.2.1'
+
+    testImplementation 'org.jetbrains.kotlin:kotlin-test'
+    testImplementation 'org.mockito:mockito-core:5.0.0'
 }

--- a/meili_flutter_android/android/src/main/kotlin/com/flutter/meili/MeiliFlutterPlugin.kt
+++ b/meili_flutter_android/android/src/main/kotlin/com/flutter/meili/MeiliFlutterPlugin.kt
@@ -1,30 +1,74 @@
 package com.flutter.meili
 
-import androidx.annotation.NonNull
-
+import android.content.Intent
+import androidx.activity.ComponentActivity
+import com.meili.travel.api.MeiliActivity
 import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.embedding.engine.plugins.activity.ActivityAware
+import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
 
-class MeiliFlutterPlugin : FlutterPlugin, MethodCallHandler {
-    private lateinit var channel: MethodChannel
+class MeiliFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
 
-    override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
-        channel = MethodChannel(flutterPluginBinding.binaryMessenger, "meili_flutter_android")
+    private lateinit var channel: MethodChannel
+    private var activity: ComponentActivity? = null
+
+    override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        channel = MethodChannel(binding.binaryMessenger, "meili_flutter_android")
         channel.setMethodCallHandler(this)
+
+        binding.platformViewRegistry.registerViewFactory(
+            "flutter_meili/meili_view",
+            MeiliViewFactory(binding.binaryMessenger) { activity },
+        )
     }
 
-    override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
-        if (call.method == "getPlatformName") {
-            result.success("Android ${android.os.Build.VERSION.RELEASE}")            
-        } else {
-            result.notImplemented()
+    override fun onMethodCall(call: MethodCall, result: Result) {
+        when (call.method) {
+            "openMeiliViewController" -> {
+                val act = activity ?: run {
+                    result.error("NO_ACTIVITY", "Activity not available", null)
+                    return
+                }
+                @Suppress("UNCHECKED_CAST")
+                val args = call.arguments as Map<String, Any?>
+                val ptid = args["ptid"] as? String ?: run {
+                    result.error("MISSING_PTID", "ptid is required", null)
+                    return
+                }
+                val envName = parseEnv(args["env"] as? String).name
+
+                val intent = Intent(act, MeiliActivity::class.java).apply {
+                    putExtra("PTID", ptid)
+                    putExtra("ENV", envName)
+                }
+                act.startActivity(intent)
+                result.success(null)
+            }
+            else -> result.notImplemented()
         }
     }
 
-    override fun onDetachedFromEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
+    override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
         channel.setMethodCallHandler(null)
+    }
+
+    override fun onAttachedToActivity(binding: ActivityPluginBinding) {
+        activity = binding.activity as? ComponentActivity
+    }
+
+    override fun onDetachedFromActivityForConfigChanges() {
+        activity = null
+    }
+
+    override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
+        activity = binding.activity as? ComponentActivity
+    }
+
+    override fun onDetachedFromActivity() {
+        activity = null
     }
 }

--- a/meili_flutter_android/android/src/main/kotlin/com/flutter/meili/MeiliParamsParser.kt
+++ b/meili_flutter_android/android/src/main/kotlin/com/flutter/meili/MeiliParamsParser.kt
@@ -1,0 +1,78 @@
+package com.flutter.meili
+
+import com.meili.travel.api.DevelopmentEnvironment
+import com.meili.travel.api.MeiliEnvironment
+import com.meili.travel.api.PreProductionEnvironment
+import com.meili.travel.api.ProductionEnvironment
+import com.meili.travel.api.UatEnvironment
+import com.meili.travel.internal.models.AvailParams
+import com.meili.travel.internal.viewModels.AdditionalParams
+
+// com.meili.travel.internal.g is the obfuscated MeiliFlow enum in the 1.1.0 AAR:
+//   g.a = Direct, g.b = BookingManager
+private typealias MeiliFlowInternal = com.meili.travel.internal.g
+
+internal fun parseEnv(envName: String?): MeiliEnvironment = when (envName?.lowercase()) {
+    "prod", "production" -> ProductionEnvironment()
+    "pre_prod", "preprod" -> PreProductionEnvironment()
+    "uat" -> UatEnvironment()
+    else -> DevelopmentEnvironment()
+}
+
+internal fun parseFlow(flowName: String?): MeiliFlowInternal = when (flowName?.lowercase()) {
+    "bookingmanager" -> MeiliFlowInternal.b
+    else -> MeiliFlowInternal.a
+}
+
+internal fun parseAvailParams(map: Map<*, *>?): AvailParams? {
+    map ?: return null
+    return AvailParams(
+        pickupLocation = map["pickupLocation"] as? String,
+        dropoffLocation = map["dropoffLocation"] as? String,
+        pickupDate = map["pickupDate"] as? String,
+        pickupTime = map["pickupTime"] as? String,
+        dropoffDate = map["dropoffDate"] as? String,
+        dropoffTime = map["dropoffTime"] as? String,
+        driverAge = (map["driverAge"] as? Number)?.toInt(),
+        currencyCode = map["currencyCode"] as? String,
+        residency = map["residency"] as? String,
+    )
+}
+
+@Suppress("UNCHECKED_CAST")
+internal fun parseAdditionalParams(map: Map<*, *>?): AdditionalParams? {
+    map ?: return null
+    val supplierAccounts = map["supplierLoyaltyAccounts"] as? List<*>
+    return AdditionalParams(
+        passengerNameRecord = map["passengerNameRecord"] as? String,
+        partnerLoyaltyAccount = map["partnerLoyaltyAccount"] as? String,
+        partnerLoyaltyAccountTier = map["partnerLoyaltyAccountTier"] as? String,
+        numberOfPassengers = (map["numberOfPassengers"] as? Number)?.toInt(),
+        customerPartnerCode = map["customerPartnerCode"] as? String,
+        flightNumber = map["flightNumber"] as? String,
+        superPassengerNameRecord = map["superPassengerNameRecord"] as? String,
+        infant = (map["infant"] as? Number)?.toInt(),
+        child = (map["child"] as? Number)?.toInt(),
+        teenager = (map["teenager"] as? Number)?.toInt(),
+        supplierLoyaltyAccount = supplierAccounts?.firstOrNull()?.toString(),
+        fareTypeAndFlex = map["fareTypeAndFlex"] as? String,
+        departureAirport = map["departureAirport"] as? String,
+        arrivalAirport = map["arrivalAirport"] as? String,
+        ancillaryActivity = map["ancillaryActivity"] as? String,
+        airlineFareAmount = (map["airlineFareAmount"] as? Number)?.toDouble(),
+        airlineFareCurrency = map["airlineFareCurrency"] as? String,
+        partnerCustomerID = map["partnerCustomerID"] as? String,
+        firstName = map["firstName"] as? String,
+        lastName = map["lastName"] as? String,
+        email = map["email"] as? String,
+        phoneNumbers = (map["phoneNumbers"] as? List<*>)?.map { it.toString() },
+        companyName = map["companyName"] as? String,
+        addressLine1 = map["addressLine1"] as? String,
+        postCode = map["postCode"] as? String,
+        city = map["city"] as? String,
+        state = map["state"] as? String,
+        confirmationId = map["confirmationId"] as? String,
+        prefillOnly = map["prefillOnly"] as? Boolean,
+        givenName = map["givenName"] as? String,
+    )
+}

--- a/meili_flutter_android/android/src/main/kotlin/com/flutter/meili/MeiliPlatformView.kt
+++ b/meili_flutter_android/android/src/main/kotlin/com/flutter/meili/MeiliPlatformView.kt
@@ -1,0 +1,41 @@
+package com.flutter.meili
+
+import android.view.View
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import com.meili.travel.api.MeiliCompose
+import io.flutter.plugin.common.BinaryMessenger
+import io.flutter.plugin.platform.PlatformView
+
+internal class MeiliPlatformView(
+    private val activity: ComponentActivity,
+    viewId: Int,
+    creationParams: Map<*, *>,
+    messenger: BinaryMessenger,
+) : PlatformView {
+
+    private val composeView = ComposeView(activity).apply {
+        setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnDetachedFromWindow)
+
+        val ptid = creationParams["ptid"] as? String ?: ""
+        val env = parseEnv(creationParams["env"] as? String)
+        val flow = parseFlow(creationParams["currentFlow"] as? String)
+        val availParams = parseAvailParams(creationParams["availParams"] as? Map<*, *>)
+        val additionalParams = parseAdditionalParams(creationParams["bookingParams"] as? Map<*, *>)
+
+        setContent {
+            MeiliCompose(
+                ptid = ptid,
+                env = env,
+                flow = flow,
+                availParams = availParams,
+                additionalParams = additionalParams,
+            )
+        }
+    }
+
+    override fun getView(): View = composeView
+
+    override fun dispose() {}
+}

--- a/meili_flutter_android/android/src/main/kotlin/com/flutter/meili/MeiliViewFactory.kt
+++ b/meili_flutter_android/android/src/main/kotlin/com/flutter/meili/MeiliViewFactory.kt
@@ -1,0 +1,24 @@
+package com.flutter.meili
+
+import android.content.Context
+import androidx.activity.ComponentActivity
+import io.flutter.plugin.common.BinaryMessenger
+import io.flutter.plugin.common.StandardMessageCodec
+import io.flutter.plugin.platform.PlatformView
+import io.flutter.plugin.platform.PlatformViewFactory
+
+internal class MeiliViewFactory(
+    private val messenger: BinaryMessenger,
+    private val activityProvider: () -> ComponentActivity?,
+) : PlatformViewFactory(StandardMessageCodec.INSTANCE) {
+
+    override fun create(context: Context, viewId: Int, args: Any?): PlatformView {
+        val params = args as? Map<*, *> ?: emptyMap<String, Any>()
+        return MeiliPlatformView(
+            activity = activityProvider() ?: error("Activity not available for MeiliPlatformView"),
+            viewId = viewId,
+            creationParams = params,
+            messenger = messenger,
+        )
+    }
+}

--- a/meili_flutter_android/pubspec.yaml
+++ b/meili_flutter_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: meili_flutter_android
 description: Android implementation of the meili_flutter plugin
-version: 0.1.1
+version: 0.2.0-beta.2
 
 homepage: https://github.com/meili-travel-tech/flutter_meili
 


### PR DESCRIPTION
Android SDK Integration — Flutter Plugin Wrapper
Overview
Implements full Android support for the meili_flutter plugin, completing cross-platform coverage alongside the existing iOS implementation.

What was done
Android plugin rewrite (meili_flutter_android)

The Kotlin plugin code was rewritten from scratch to target the actual published ux-native-android-sdk 1.1.0 AAR. The published artifact differs significantly from local source due to R8 obfuscation — internal classes are renamed and several API surface items (listener callbacks, MeiliActivity.start(), MeiliFlow sealed class) do not exist in the published version. Changes were derived by directly inspecting the AAR bytecode with javap.

MeiliFlutterPlugin.kt — implements FlutterPlugin, MethodCallHandler, ActivityAware. Handles openMeiliViewController by launching MeiliActivity via Intent with PTID and ENV extras (the only extras the 1.1.0 onCreate reads from bytecode inspection). Registers MeiliViewFactory for the flutter_meili/meili_view platform view type.
MeiliParamsParser.kt — replaces the non-existent MeiliFlow sealed class with a typealias to com.meili.travel.internal.g (the obfuscated enum in 1.1.0, where g.a = Direct, g.b = BookingManager, confirmed via constant pool inspection). Adds missing givenName field to AdditionalParams construction to match the 30-param constructor in 1.1.0.
MeiliPlatformView.kt — embeds MeiliCompose inside a ComposeView hosted in a Flutter PlatformView. Removes listener and onBack parameters which do not exist in the 1.1.0 MeiliCompose signature.
MeiliViewFactory.kt — PlatformViewFactory that creates MeiliPlatformView instances, passing activity reference via lambda.
Gradle / build configuration

Migrated example app settings.gradle to declarative plugins DSL
Added org.jetbrains.kotlin.plugin.compose 2.1.0 (required for Kotlin 2.x Compose)
Pinned ndkVersion = "27.0.12077973"
Set minSdk = 27
Configured GitHub Packages Maven repo with env var credentials for SDK resolution
Flutter-side fixes

MainActivity must extend FlutterFragmentActivity — FlutterActivity extends Activity directly (not ComponentActivity), causing the as? ComponentActivity cast to silently return null and breaking platform view creation
Exported MeiliView widget from the package barrel file (meili_flutter.dart) — it was missing from exports
Added AndroidView branch to meili_view.dart alongside the existing UiKitView
Published

meili_flutter_android 0.2.0-beta.1 → pub.dev
meili_flutter 0.3.1-beta.1 → pub.dev
README

Full partner integration guide added covering credentials setup, all required Android file changes, iOS setup, usage examples, and a troubleshooting reference table.

Partner integration requirements
MEILI_GITHUB_USERNAME + MEILI_GITHUB_TOKEN env vars (GitHub PAT with read:packages)
GitHub Packages Maven repo block in android/build.gradle.kts
minSdk = 27, ndkVersion = "27.0.12077973" in android/app/build.gradle.kts
org.jetbrains.kotlin.plugin.compose 2.1.0 in android/settings.gradle.kts
MainActivity extending FlutterFragmentActivity