### PR TITLE
MPD-10554: Bump MeiliSDK to 1.6.3-alpha.10 (meili_flutter_ios)

### DIFF
--- a/meili_flutter/example/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/meili_flutter/example/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/meili-travel-tech/ux-native-ios",
       "state" : {
-        "revision" : "c9d49ad1284f3074e2ab6d78ee8bd368de9fd335",
-        "version" : "1.6.3-alpha.9"
+        "revision" : "faf110c8b9ebded0c2f8c40ae170568a1d18b2ee",
+        "version" : "1.6.3-alpha.10"
       }
     }
   ],

--- a/meili_flutter/example/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/meili_flutter/example/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/meili-travel-tech/ux-native-ios",
       "state" : {
-        "revision" : "c9d49ad1284f3074e2ab6d78ee8bd368de9fd335",
-        "version" : "1.6.3-alpha.9"
+        "revision" : "faf110c8b9ebded0c2f8c40ae170568a1d18b2ee",
+        "version" : "1.6.3-alpha.10"
       }
     }
   ],

--- a/meili_flutter_ios/CHANGELOG.md
+++ b/meili_flutter_ios/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.1-beta.4
+
+- Bumped `MeiliSDK` to `1.6.3-alpha.10` on both channels (SwiftPM `ux-native-ios` pin and CocoaPods podspec).
+
 ## 0.3.1-beta.3
 
 - Updated `meili_flutter_platform_interface` constraint to `^0.3.0`.

--- a/meili_flutter_ios/ios/meili_flutter_ios.podspec
+++ b/meili_flutter_ios/ios/meili_flutter_ios.podspec
@@ -21,5 +21,5 @@ Pod::Spec.new do |s|
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
   s.swift_version = '5.0'
-  s.dependency 'MeiliSDK', '1.6.3-alpha.9'
+  s.dependency 'MeiliSDK', '1.6.3-alpha.10'
 end

--- a/meili_flutter_ios/ios/meili_flutter_ios/Package.swift
+++ b/meili_flutter_ios/ios/meili_flutter_ios/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
         // `exact:` (not `from:`) because only pre-release tags exist today
         // (1.6.3-alpha.N); SwiftPM excludes pre-releases from `from:` ranges.
         // Switch to `from: "1.6.0"` once a stable 1.6.x ships.
-        .package(url: "https://github.com/meili-travel-tech/ux-native-ios", exact: "1.6.3-alpha.9")
+        .package(url: "https://github.com/meili-travel-tech/ux-native-ios", exact: "1.6.3-alpha.10")
     ],
     targets: [
         .target(

--- a/meili_flutter_ios/pubspec.yaml
+++ b/meili_flutter_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: meili_flutter_ios
 description: iOS implementation of the meili_flutter plugin
-version: 0.3.1-beta.3
+version: 0.3.1-beta.4
 
 homepage: https://github.com/meili-travel-tech/flutter_meili
 


### PR DESCRIPTION
## Summary

Bumps the iOS plugin's bundled native SDK pin from `1.6.3-alpha.9` to `1.6.3-alpha.10` on **both** distribution channels, keeping them aligned (they resolve the same `MeiliSDK.xcframework`):

- **SwiftPM** — `Package.swift` `exact: "1.6.3-alpha.10"` + example app `Package.resolved` lockfiles (rev `faf110c8…`).
- **CocoaPods** — podspec `MeiliSDK` dependency → `1.6.3-alpha.10` (the `1.6.3-alpha.10` podspec is published on the `meili-ios-pods` spec repo).
- **Plugin version** — `meili_flutter_ios` `0.3.1-beta.3` → `0.3.1-beta.4` + CHANGELOG entry. The app-facing `meili_flutter` (already `0.3.1-beta.4`) constrains `^0.3.1-beta.3`, which this satisfies — no change needed there.

## Testing

- Verified the `1.6.3-alpha.10` tag exists on `ux-native-ios` and the matching podspec is published on `meili-ios-pods`.
- Example app built and ran against `1.6.3-alpha.10` via the SwiftPM channel (confirmed locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)