### PR TITLE
MPD-10696 Add inline tester settings to Flutter example app

### DIFF
--- a/meili_flutter/example/README.md
+++ b/meili_flutter/example/README.md
@@ -1,3 +1,46 @@
 # meili_flutter_example
 
-Demonstrates how to use the meili_flutter plugin.
+Demonstrates how to use the meili_flutter plugin. The app is a small host that
+configures launch settings (PTID, environment, flow, etc.) inline and opens the
+Meili SDK — see `lib/widgets/launch_view.dart`.
+
+## Local development vs published plugin
+
+The example can build against either the **in-repo plugin source** (for testing
+local changes) or the **published `meili_flutter`** from pub.dev (what a real
+consumer gets, used for Play Store releases). This is controlled by
+`pubspec_overrides.yaml`, not by the build mode (`--debug`/`--release`).
+
+### Local development (default)
+
+`pubspec_overrides.yaml` is committed and redirects `meili_flutter` and the
+federated platform packages to the in-repo source. Nothing extra to do:
+
+```bash
+flutter pub get
+flutter run            # or: flutter build apk --release
+```
+
+`flutter pub get` resolves the plugin packages to local paths (verify in
+`pubspec.lock`).
+
+### Published plugin (Play Store release)
+
+1. Publish the plugin (`meili_flutter`) to pub.dev.
+2. Bump the `meili_flutter:` constraint in `pubspec.yaml` to the published
+   version.
+3. Build with the overrides disabled:
+
+```bash
+export MEILI_GITHUB_USERNAME=... MEILI_GITHUB_TOKEN=...   # native Android SDK
+scripts/build_published.sh            # release .aab against the published plugin
+# scripts/build_published.sh apk      # release .apk instead
+```
+
+The script temporarily sidelines `pubspec_overrides.yaml`, runs `flutter pub
+get` (resolving `meili_flutter` from pub.dev), builds the release artifact, then
+restores local-dev mode.
+
+> Note: the example's release build type is signed with the debug keystore. Add
+> a real `signingConfig` (keystore + `key.properties`) in
+> `android/app/build.gradle` before uploading to the Play Store.

--- a/meili_flutter/example/android/app/build.gradle
+++ b/meili_flutter/example/android/app/build.gradle
@@ -4,8 +4,18 @@ plugins {
     id "dev.flutter.flutter-gradle-plugin"
 }
 
+// Release signing is read from android/key.properties when present (that file
+// and the keystore are git-ignored). Without it, release builds fall back to
+// the debug keystore so local/CI builds still work — but a debug-signed
+// artifact cannot be uploaded to the Play Store. See android/key.properties.example.
+def keystoreProperties = new Properties()
+def keystorePropertiesFile = rootProject.file("key.properties")
+if (keystorePropertiesFile.exists()) {
+    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+}
+
 android {
-    namespace "com.flutter.meili.example"
+    namespace "com.meili.travel.sample.flutter"
     compileSdk flutter.compileSdkVersion
 
     compileOptions {
@@ -21,19 +31,33 @@ android {
         main.java.srcDirs += "src/main/kotlin"
     }
 
-    ndkVersion "26.3.11579264"
+    // Highest NDK required across the Flutter plugins (integration_test);
+    // needed so release builds can strip native debug symbols cleanly.
+    ndkVersion "28.2.13676358"
 
     defaultConfig {
-        applicationId "com.flutter.meili.example"
+        applicationId "com.meili.travel.sample.flutter"
         minSdk 27
         targetSdk flutter.targetSdkVersion
         versionCode flutter.versionCode
         versionName flutter.versionName
     }
 
+    signingConfigs {
+        release {
+            if (keystorePropertiesFile.exists()) {
+                keyAlias keystoreProperties["keyAlias"]
+                keyPassword keystoreProperties["keyPassword"]
+                storeFile keystoreProperties["storeFile"] ? file(keystoreProperties["storeFile"]) : null
+                storePassword keystoreProperties["storePassword"]
+            }
+        }
+    }
+
     buildTypes {
         release {
-            signingConfig signingConfigs.debug
+            // Real keystore when configured, debug keystore otherwise.
+            signingConfig keystorePropertiesFile.exists() ? signingConfigs.release : signingConfigs.debug
         }
     }
 }

--- a/meili_flutter/example/android/app/src/debug/AndroidManifest.xml
+++ b/meili_flutter/example/android/app/src/debug/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.flutter.meili.example">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->

--- a/meili_flutter/example/android/app/src/main/AndroidManifest.xml
+++ b/meili_flutter/example/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.flutter.meili.example">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
-        android:label="example"
+        android:label="Meili Sample"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/meili_flutter/example/android/app/src/main/kotlin/com/meili/travel/sample/flutter/MainActivity.kt
+++ b/meili_flutter/example/android/app/src/main/kotlin/com/meili/travel/sample/flutter/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.flutter.meili.example
+package com.meili.travel.sample.flutter
 
 import io.flutter.embedding.android.FlutterFragmentActivity
 

--- a/meili_flutter/example/android/app/src/profile/AndroidManifest.xml
+++ b/meili_flutter/example/android/app/src/profile/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.flutter.meili">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->

--- a/meili_flutter/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/meili_flutter/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-all.zip

--- a/meili_flutter/example/android/key.properties.example
+++ b/meili_flutter/example/android/key.properties.example
@@ -1,0 +1,13 @@
+# Android release signing — copy this file to `android/key.properties` and fill
+# in your values. The real `key.properties` and the keystore are git-ignored;
+# NEVER commit them.
+#
+# Generate an upload keystore once:
+#   keytool -genkey -v -keystore ~/upload-keystore.jks \
+#     -keyalg RSA -keysize 2048 -validity 10000 -alias upload
+#
+storePassword=YOUR_KEYSTORE_PASSWORD
+keyPassword=YOUR_KEY_PASSWORD
+keyAlias=upload
+# Absolute path is simplest; a relative path resolves against android/app/.
+storeFile=/absolute/path/to/upload-keystore.jks

--- a/meili_flutter/example/android/settings.gradle
+++ b/meili_flutter/example/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.3.0" apply false
+    id "com.android.application" version "8.7.3" apply false
     id "org.jetbrains.kotlin.android" version "2.1.0" apply false
     id "org.jetbrains.kotlin.plugin.compose" version "2.1.0" apply false
 }

--- a/meili_flutter/example/integration_test/app_test.dart
+++ b/meili_flutter/example/integration_test/app_test.dart
@@ -6,16 +6,19 @@ void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   group('E2E', () {
-    testWidgets('launches with the supported flow tabs and an empty Events tab',
+    testWidgets('launches on the configure screen with an empty Events tab',
         (tester) async {
-      app.main();
+      await app.main();
       await tester.pumpAndSettle();
 
-      // Only Direct and Booking Manager flows are exposed (Connect removed),
-      // plus the Events tab.
+      // The Launch tab hosts the inline settings; the Events tab is separate.
+      expect(find.text('Launch'), findsOneWidget);
+      expect(find.text('Events'), findsOneWidget);
+
+      // Inline settings are visible on the launch screen.
+      expect(find.text('PTID'), findsOneWidget);
       expect(find.text('Direct'), findsOneWidget);
       expect(find.text('Booking Manager'), findsOneWidget);
-      expect(find.text('Events'), findsOneWidget);
 
       await tester.tap(find.text('Events'));
       await tester.pumpAndSettle();

--- a/meili_flutter/example/ios/Podfile
+++ b/meili_flutter/example/ios/Podfile
@@ -1,3 +1,7 @@
+# Declaring any custom source disables CocoaPods' implicit default trunk, so the
+# CDN must be listed explicitly — otherwise federated plugins (e.g.
+# shared_preferences_foundation) fail to resolve on clean machines/CI.
+source 'https://cdn.cocoapods.org/'
 source 'https://github.com/meili-travel-tech/meili-ios-pods'
 
 # Uncomment this line to define a global platform for your project

--- a/meili_flutter/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/meili_flutter/example/ios/Runner.xcodeproj/project.pbxproj
@@ -361,7 +361,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.flutter.meili;
+				PRODUCT_BUNDLE_IDENTIFIER = com.meili.travel.sample.flutter;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -490,7 +490,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.flutter.meili;
+				PRODUCT_BUNDLE_IDENTIFIER = com.meili.travel.sample.flutter;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -513,7 +513,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.flutter.meili;
+				PRODUCT_BUNDLE_IDENTIFIER = com.meili.travel.sample.flutter;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/meili_flutter/example/ios/Runner/Info.plist
+++ b/meili_flutter/example/ios/Runner/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Example</string>
+	<string>Meili Sample</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/meili_flutter/example/lib/launch_view_model.dart
+++ b/meili_flutter/example/lib/launch_view_model.dart
@@ -1,0 +1,78 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:meili_flutter/meili_flutter.dart';
+import 'package:meili_flutter_example/meili_settings.dart';
+import 'package:meili_flutter_example/settings_repository.dart';
+
+/// Owns the editable launch [MeiliSettings], persists every change, drives the
+/// SDK launch, and surfaces one-shot toast messages (MVVM, per the project's
+/// Flutter architecture skill).
+class LaunchViewModel extends ChangeNotifier {
+  /// Creates the view model, loading the persisted settings synchronously.
+  ///
+  /// [events] is injectable for testing; it defaults to [Meili.events].
+  LaunchViewModel({
+    required SettingsRepository repository,
+    Stream<MeiliEvent>? events,
+  })  : _repository = repository,
+        _settings = repository.load() {
+    _subscription = (events ?? Meili.events).listen(_onEvent);
+  }
+
+  final SettingsRepository _repository;
+  late final StreamSubscription<MeiliEvent> _subscription;
+  final StreamController<String> _toasts = StreamController<String>.broadcast();
+
+  MeiliSettings _settings;
+  bool _isLaunching = false;
+
+  /// The current (persisted) settings snapshot.
+  MeiliSettings get settings => _settings;
+
+  /// Whether a launch is in flight (the launch button is disabled meanwhile).
+  bool get isLaunching => _isLaunching;
+
+  /// One-shot toast messages: booking notifications and launch errors.
+  Stream<String> get toasts => _toasts.stream;
+
+  /// Applies [settings] in memory and persists them.
+  void update(MeiliSettings settings) {
+    _settings = settings;
+    notifyListeners();
+    unawaited(_repository.save(settings));
+  }
+
+  /// Restores the iOS-matching defaults.
+  void resetToDefaults() => update(const MeiliSettings());
+
+  /// Launches the Meili SDK modally with the current settings.
+  Future<void> launch() async {
+    if (_isLaunching) {
+      return;
+    }
+    _isLaunching = true;
+    notifyListeners();
+    try {
+      await Meili.openMeiliView(_settings.toMeiliParams());
+    } on Object catch (error) {
+      _toasts.add('Failed to open Meili: $error');
+    } finally {
+      _isLaunching = false;
+      notifyListeners();
+    }
+  }
+
+  void _onEvent(MeiliEvent event) {
+    if (event is MeiliBookingFlowEnded && _settings.showBookingToast) {
+      _toasts.add('Booking flow ended');
+    }
+  }
+
+  @override
+  void dispose() {
+    _subscription.cancel();
+    _toasts.close();
+    super.dispose();
+  }
+}

--- a/meili_flutter/example/lib/main.dart
+++ b/meili_flutter/example/lib/main.dart
@@ -1,149 +1,116 @@
-import 'package:flutter/cupertino.dart';
-import 'package:meili_flutter/meili_flutter.dart';
+import 'package:flutter/material.dart';
 
 import 'package:meili_flutter_example/events_view_model.dart';
+import 'package:meili_flutter_example/launch_view_model.dart';
+import 'package:meili_flutter_example/settings_repository.dart';
 import 'package:meili_flutter_example/widgets/events_panel.dart';
+import 'package:meili_flutter_example/widgets/launch_view.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
-void main() => runApp(const MyApp());
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  final prefs = await SharedPreferences.getInstance();
+  runApp(MyApp(repository: SettingsRepository(prefs)));
+}
 
 class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+  const MyApp({required this.repository, super.key});
+
+  /// Settings store loaded before the app starts so the UI can read it
+  /// synchronously.
+  final SettingsRepository repository;
 
   @override
   Widget build(BuildContext context) {
-    return const CupertinoApp(home: TabHomePage());
+    return MaterialApp(
+      title: 'Meili Sample',
+      theme: ThemeData(
+        useMaterial3: true,
+        colorSchemeSeed: const Color(0xFF1E88E5),
+      ),
+      home: HomePage(repository: repository),
+    );
   }
 }
 
-class TabHomePage extends StatefulWidget {
-  const TabHomePage({super.key});
+class HomePage extends StatefulWidget {
+  const HomePage({required this.repository, super.key});
+
+  /// The settings store passed to the launch view model.
+  final SettingsRepository repository;
 
   @override
-  State<TabHomePage> createState() => _TabHomePageState();
+  State<HomePage> createState() => _HomePageState();
 }
 
-class _TabHomePageState extends State<TabHomePage> {
+class _HomePageState extends State<HomePage> {
+  late final LaunchViewModel _launchViewModel;
   late final EventsViewModel _eventsViewModel;
+  int _index = 0;
 
   @override
   void initState() {
     super.initState();
+    _launchViewModel = LaunchViewModel(repository: widget.repository);
     _eventsViewModel = EventsViewModel();
   }
 
   @override
   void dispose() {
+    _launchViewModel.dispose();
     _eventsViewModel.dispose();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    return CupertinoTabScaffold(
-      tabBar: CupertinoTabBar(
-        items: const <BottomNavigationBarItem>[
-          BottomNavigationBarItem(
-            label: 'Direct',
-            icon: Icon(CupertinoIcons.arrow_right),
+    return Scaffold(
+      body: IndexedStack(
+        index: _index,
+        children: [
+          LaunchView(viewModel: _launchViewModel),
+          EventsView(viewModel: _eventsViewModel),
+        ],
+      ),
+      bottomNavigationBar: NavigationBar(
+        selectedIndex: _index,
+        onDestinationSelected: (index) => setState(() => _index = index),
+        destinations: const <NavigationDestination>[
+          NavigationDestination(
+            icon: Icon(Icons.tune),
+            label: 'Launch',
           ),
-          BottomNavigationBarItem(
-            label: 'Booking Manager',
-            icon: Icon(CupertinoIcons.person),
-          ),
-          BottomNavigationBarItem(
+          NavigationDestination(
+            icon: Icon(Icons.list_alt),
             label: 'Events',
-            icon: Icon(CupertinoIcons.list_bullet),
           ),
         ],
       ),
-      tabBuilder: (context, index) {
-        switch (index) {
-          case 0:
-            return const MeiliDirectFlowButton();
-          case 1:
-            return const MeiliBookingManagerFlowButton();
-          case 2:
-            return EventsTab(viewModel: _eventsViewModel);
-          default:
-            return Container();
-        }
-      },
     );
   }
 }
 
-/// Tab that shows the live Meili event log, sourced from [Meili.events].
-class EventsTab extends StatelessWidget {
-  /// Creates the events tab bound to [viewModel].
-  const EventsTab({required this.viewModel, super.key});
+/// Tab that shows the live Meili event log, sourced from [EventsViewModel].
+class EventsView extends StatelessWidget {
+  /// Creates the events view bound to [viewModel].
+  const EventsView({required this.viewModel, super.key});
 
   /// The shared events view model.
   final EventsViewModel viewModel;
 
   @override
   Widget build(BuildContext context) {
-    return CupertinoPageScaffold(
-      navigationBar: CupertinoNavigationBar(
-        middle: const Text('Meili Events'),
-        trailing: CupertinoButton(
-          padding: EdgeInsets.zero,
-          onPressed: viewModel.clear,
-          child: const Text('Clear'),
-        ),
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Meili Events'),
+        actions: [
+          TextButton(
+            onPressed: viewModel.clear,
+            child: const Text('Clear'),
+          ),
+        ],
       ),
-      child: SafeArea(child: EventsPanel(viewModel: viewModel)),
-    );
-  }
-}
-
-class MeiliDirectFlowButton extends StatelessWidget {
-  const MeiliDirectFlowButton({super.key});
-
-  Future<void> _openMeiliView() async {
-    final params = MeiliParams(
-      ptid: '100.9',
-      flow: FlowType.direct,
-      env: 'dev',
-    );
-
-    try {
-      await Meili.openMeiliView(params);
-    } catch (e) {
-      print('Failed to open MeiliView: $e');
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return CupertinoButton(
-      onPressed: _openMeiliView,
-      child: const Text('Open Meili Direct'),
-    );
-  }
-}
-
-class MeiliBookingManagerFlowButton extends StatelessWidget {
-  const MeiliBookingManagerFlowButton({super.key});
-
-  Future<void> _openMeiliView() async {
-    final params = MeiliParams(
-      ptid: '100.9',
-      flow: FlowType.bookingManager,
-      env: 'dev',
-    );
-
-    try {
-      await Meili.openMeiliView(params);
-    } catch (e) {
-      print('Failed to open MeiliView: $e');
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return CupertinoButton(
-      onPressed: _openMeiliView,
-      child: const Text('Open Meili Booking Manager'),
+      body: EventsPanel(viewModel: viewModel),
     );
   }
 }

--- a/meili_flutter/example/lib/meili_settings.dart
+++ b/meili_flutter/example/lib/meili_settings.dart
@@ -1,0 +1,167 @@
+import 'package:meili_flutter/meili_flutter.dart';
+
+/// The API environment the sample app points the SDK at.
+///
+/// Mirrors the iOS Sample App's environment picker. [wireValue] is the raw
+/// string passed to [MeiliParams.env]; [label] is what the picker shows.
+enum MeiliEnv {
+  dev('dev', 'Dev'),
+  uat('uat', 'UAT'),
+  preProd('preProd', 'Pre-Prod'),
+  prod('prod', 'Prod');
+
+  const MeiliEnv(this.wireValue, this.label);
+
+  /// The value sent to the native SDK via [MeiliParams.env].
+  final String wireValue;
+
+  /// The human-readable label shown in the picker.
+  final String label;
+
+  /// Resolves a persisted [wireValue] back to an enum, defaulting to [dev].
+  static MeiliEnv fromWire(String? value) => MeiliEnv.values.firstWhere(
+        (env) => env.wireValue == value,
+        orElse: () => MeiliEnv.dev,
+      );
+}
+
+/// Immutable snapshot of every launch setting a tester can configure.
+///
+/// Defaults match the iOS Sample App (`SettingsViewModel`) so the two sample
+/// apps behave the same out of the box.
+class MeiliSettings {
+  /// Creates a settings snapshot. All fields default to the iOS values.
+  const MeiliSettings({
+    this.ptid = '100.9',
+    this.env = MeiliEnv.dev,
+    this.flow = FlowType.direct,
+    this.overrideCurrency = false,
+    this.currency = 'EUR',
+    this.confirmationId = '',
+    this.lastName = '',
+    this.prefillOnly = false,
+    this.showBookingToast = false,
+  });
+
+  /// Rebuilds a snapshot from its [toJson] representation.
+  factory MeiliSettings.fromJson(Map<String, dynamic> json) => MeiliSettings(
+        ptid: json['ptid'] as String? ?? '100.9',
+        env: MeiliEnv.fromWire(json['env'] as String?),
+        flow: json['flow'] == 'bookingManager'
+            ? FlowType.bookingManager
+            : FlowType.direct,
+        overrideCurrency: json['overrideCurrency'] as bool? ?? false,
+        currency: json['currency'] as String? ?? 'EUR',
+        confirmationId: json['confirmationId'] as String? ?? '',
+        lastName: json['lastName'] as String? ?? '',
+        prefillOnly: json['prefillOnly'] as bool? ?? false,
+        showBookingToast: json['showBookingToast'] as bool? ?? false,
+      );
+
+  /// Partner / touchpoint id passed to [MeiliParams.ptid].
+  final String ptid;
+
+  /// Selected API environment.
+  final MeiliEnv env;
+
+  /// Selected booking flow.
+  final FlowType flow;
+
+  /// Whether to send a currency override via [AvailParams].
+  final bool overrideCurrency;
+
+  /// Currency code used when [overrideCurrency] is on.
+  final String currency;
+
+  /// Booking confirmation id for the Booking Manager flow.
+  final String confirmationId;
+
+  /// Customer last name for the Booking Manager flow.
+  final String lastName;
+
+  /// Whether the booking form should only be prefilled.
+  final bool prefillOnly;
+
+  /// Whether to show a toast when a booking flow ends.
+  final bool showBookingToast;
+
+  /// Returns a copy with the provided fields replaced.
+  MeiliSettings copyWith({
+    String? ptid,
+    MeiliEnv? env,
+    FlowType? flow,
+    bool? overrideCurrency,
+    String? currency,
+    String? confirmationId,
+    String? lastName,
+    bool? prefillOnly,
+    bool? showBookingToast,
+  }) {
+    return MeiliSettings(
+      ptid: ptid ?? this.ptid,
+      env: env ?? this.env,
+      flow: flow ?? this.flow,
+      overrideCurrency: overrideCurrency ?? this.overrideCurrency,
+      currency: currency ?? this.currency,
+      confirmationId: confirmationId ?? this.confirmationId,
+      lastName: lastName ?? this.lastName,
+      prefillOnly: prefillOnly ?? this.prefillOnly,
+      showBookingToast: showBookingToast ?? this.showBookingToast,
+    );
+  }
+
+  /// Serializes the settings for persistence.
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'ptid': ptid,
+        'env': env.wireValue,
+        'flow': flow.name,
+        'overrideCurrency': overrideCurrency,
+        'currency': currency,
+        'confirmationId': confirmationId,
+        'lastName': lastName,
+        'prefillOnly': prefillOnly,
+        'showBookingToast': showBookingToast,
+      };
+
+  /// Builds the [MeiliParams] used to launch the SDK from these settings.
+  MeiliParams toMeiliParams() {
+    return MeiliParams(
+      ptid: ptid,
+      flow: flow,
+      env: env.wireValue,
+      availParams: overrideCurrency ? _currencyOnlyAvailParams() : null,
+      additionalParams: _additionalParams(),
+    );
+  }
+
+  /// Booking-manager params, or null when nothing meaningful is set.
+  AdditionalParams? _additionalParams() {
+    final hasConfirmation = confirmationId.isNotEmpty;
+    final hasLastName = lastName.isNotEmpty;
+    if (!hasConfirmation && !hasLastName && !prefillOnly) {
+      return null;
+    }
+    return AdditionalParams(
+      confirmationId: hasConfirmation ? confirmationId : null,
+      lastName: hasLastName ? lastName : null,
+      prefillOnly: prefillOnly,
+    );
+  }
+
+  /// The Flutter [AvailParams] requires every field, unlike iOS which can set
+  /// the currency alone. The non-currency fields are intentionally left empty
+  /// so the native layer treats them as unset — see MPD-10696 for the gap.
+  AvailParams _currencyOnlyAvailParams() {
+    return AvailParams(
+      pickupLocation: '',
+      dropoffLocation: '',
+      pickupDate: '',
+      pickupTime: '',
+      dropoffDate: '',
+      dropoffTime: '',
+      driverAge: 0,
+      currencyCode: currency,
+      residency: '',
+    );
+  }
+}

--- a/meili_flutter/example/lib/settings_repository.dart
+++ b/meili_flutter/example/lib/settings_repository.dart
@@ -1,0 +1,36 @@
+import 'dart:convert';
+
+import 'package:meili_flutter_example/meili_settings.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Persists [MeiliSettings] in `SharedPreferences` as a single JSON blob.
+///
+/// A [SharedPreferences] instance is injected so the repository stays a thin,
+/// testable wrapper (MVVM data layer, per the project's architecture skill).
+class SettingsRepository {
+  /// Creates a repository backed by an already-loaded `SharedPreferences`.
+  SettingsRepository(this._prefs);
+
+  static const String _key = 'meili.sample.settings';
+
+  final SharedPreferences _prefs;
+
+  /// Reads the saved settings, falling back to defaults when absent/invalid.
+  MeiliSettings load() {
+    final raw = _prefs.getString(_key);
+    if (raw == null) {
+      return const MeiliSettings();
+    }
+    try {
+      final json = jsonDecode(raw) as Map<String, dynamic>;
+      return MeiliSettings.fromJson(json);
+    } on FormatException {
+      return const MeiliSettings();
+    }
+  }
+
+  /// Persists [settings].
+  Future<void> save(MeiliSettings settings) {
+    return _prefs.setString(_key, jsonEncode(settings.toJson()));
+  }
+}

--- a/meili_flutter/example/lib/widgets/events_panel.dart
+++ b/meili_flutter/example/lib/widgets/events_panel.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 import 'package:meili_flutter/meili_flutter.dart';
 import 'package:meili_flutter_example/events_view_model.dart';
 
@@ -24,8 +24,9 @@ class EventsPanel extends StatelessWidget {
             ),
           );
         }
-        return ListView.builder(
+        return ListView.separated(
           itemCount: records.length,
+          separatorBuilder: (context, index) => const Divider(height: 1),
           itemBuilder: (context, index) {
             final record = records[index];
             return _EventTile(
@@ -46,21 +47,10 @@ class _EventTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
-      decoration: const BoxDecoration(
-        border: Border(
-          bottom: BorderSide(color: CupertinoColors.separator, width: 0.5),
-        ),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(_title, style: const TextStyle(fontWeight: FontWeight.bold)),
-          if (_subtitle != null)
-            Text(_subtitle!, style: const TextStyle(fontSize: 13)),
-        ],
-      ),
+    final subtitle = _subtitle;
+    return ListTile(
+      title: Text(_title),
+      subtitle: subtitle == null ? null : Text(subtitle),
     );
   }
 

--- a/meili_flutter/example/lib/widgets/launch_view.dart
+++ b/meili_flutter/example/lib/widgets/launch_view.dart
@@ -1,0 +1,265 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:meili_flutter/meili_flutter.dart';
+import 'package:meili_flutter_example/launch_view_model.dart';
+import 'package:meili_flutter_example/meili_settings.dart';
+
+/// The single "configure & launch" screen.
+///
+/// Inline settings (matching the iOS Sample App, MPD-10696) sit directly above
+/// the launch button — tweak, then launch, no separate settings page.
+class LaunchView extends StatefulWidget {
+  /// Creates the launch view bound to [viewModel].
+  const LaunchView({required this.viewModel, super.key});
+
+  /// The view model holding the editable settings.
+  final LaunchViewModel viewModel;
+
+  @override
+  State<LaunchView> createState() => _LaunchViewState();
+}
+
+class _LaunchViewState extends State<LaunchView> {
+  final GlobalKey<ScaffoldMessengerState> _messengerKey =
+      GlobalKey<ScaffoldMessengerState>();
+  late final TextEditingController _ptidController;
+  late final TextEditingController _currencyController;
+  late final TextEditingController _confirmationIdController;
+  late final TextEditingController _lastNameController;
+  StreamSubscription<String>? _toastSubscription;
+
+  LaunchViewModel get _vm => widget.viewModel;
+
+  @override
+  void initState() {
+    super.initState();
+    final settings = _vm.settings;
+    _ptidController = TextEditingController(text: settings.ptid);
+    _currencyController = TextEditingController(text: settings.currency);
+    _confirmationIdController =
+        TextEditingController(text: settings.confirmationId);
+    _lastNameController = TextEditingController(text: settings.lastName);
+    _toastSubscription = _vm.toasts.listen(_showSnack);
+  }
+
+  @override
+  void dispose() {
+    _toastSubscription?.cancel();
+    _ptidController.dispose();
+    _currencyController.dispose();
+    _confirmationIdController.dispose();
+    _lastNameController.dispose();
+    super.dispose();
+  }
+
+  void _showSnack(String message) {
+    _messengerKey.currentState
+      ?..hideCurrentSnackBar()
+      ..showSnackBar(SnackBar(content: Text(message)));
+  }
+
+  void _resetToDefaults() {
+    _vm.resetToDefaults();
+    final settings = _vm.settings;
+    _ptidController.text = settings.ptid;
+    _currencyController.text = settings.currency;
+    _confirmationIdController.text = settings.confirmationId;
+    _lastNameController.text = settings.lastName;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ScaffoldMessenger(
+      key: _messengerKey,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Meili Sample'),
+          actions: [
+            TextButton(
+              onPressed: _resetToDefaults,
+              child: const Text('Reset'),
+            ),
+          ],
+        ),
+        body: ListenableBuilder(
+          listenable: _vm,
+          builder: (context, _) => _buildForm(_vm.settings),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildForm(MeiliSettings settings) {
+    return ListView(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      children: [
+        const _SectionHeader('General'),
+        _FieldPadding(
+          child: TextField(
+            controller: _ptidController,
+            decoration: const InputDecoration(
+              labelText: 'PTID',
+              border: OutlineInputBorder(),
+            ),
+            onChanged: (value) => _vm.update(settings.copyWith(ptid: value)),
+          ),
+        ),
+        ListTile(
+          title: const Text('Environment'),
+          trailing: DropdownButton<MeiliEnv>(
+            value: settings.env,
+            onChanged: (value) {
+              if (value != null) {
+                _vm.update(settings.copyWith(env: value));
+              }
+            },
+            items: [
+              for (final env in MeiliEnv.values)
+                DropdownMenuItem<MeiliEnv>(
+                  value: env,
+                  child: Text(env.label),
+                ),
+            ],
+          ),
+        ),
+        _FieldPadding(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('Flow', style: Theme.of(context).textTheme.bodySmall),
+              const SizedBox(height: 8),
+              SegmentedButton<FlowType>(
+                segments: const [
+                  ButtonSegment<FlowType>(
+                    value: FlowType.direct,
+                    label: Text('Direct'),
+                  ),
+                  ButtonSegment<FlowType>(
+                    value: FlowType.bookingManager,
+                    label: Text('Booking Manager'),
+                  ),
+                ],
+                selected: {settings.flow},
+                onSelectionChanged: (selection) =>
+                    _vm.update(settings.copyWith(flow: selection.first)),
+              ),
+            ],
+          ),
+        ),
+        const _SectionHeader('Currency'),
+        SwitchListTile(
+          title: const Text('Override currency'),
+          value: settings.overrideCurrency,
+          onChanged: (value) =>
+              _vm.update(settings.copyWith(overrideCurrency: value)),
+        ),
+        if (settings.overrideCurrency)
+          _FieldPadding(
+            child: TextField(
+              controller: _currencyController,
+              decoration: const InputDecoration(
+                labelText: 'Currency',
+                border: OutlineInputBorder(),
+              ),
+              onChanged: (value) =>
+                  _vm.update(settings.copyWith(currency: value)),
+            ),
+          ),
+        // The booking lookup fields only apply to the Booking Manager flow,
+        // so hide the whole section for the Direct flow to avoid confusion.
+        if (settings.flow == FlowType.bookingManager) ...[
+          const _SectionHeader('Manage My Booking'),
+          _FieldPadding(
+            child: TextField(
+              controller: _confirmationIdController,
+              decoration: const InputDecoration(
+                labelText: 'Confirmation Id',
+                border: OutlineInputBorder(),
+              ),
+              onChanged: (value) =>
+                  _vm.update(settings.copyWith(confirmationId: value)),
+            ),
+          ),
+          _FieldPadding(
+            child: TextField(
+              controller: _lastNameController,
+              decoration: const InputDecoration(
+                labelText: 'Last Name',
+                border: OutlineInputBorder(),
+              ),
+              onChanged: (value) =>
+                  _vm.update(settings.copyWith(lastName: value)),
+            ),
+          ),
+          SwitchListTile(
+            title: const Text('Prefill only'),
+            value: settings.prefillOnly,
+            onChanged: (value) =>
+                _vm.update(settings.copyWith(prefillOnly: value)),
+          ),
+        ],
+        const _SectionHeader('Notifications'),
+        SwitchListTile(
+          title: const Text('Show booking toast'),
+          subtitle: const Text(
+            'Show a snackbar when a booking flow ends. The native event '
+            'carries no booking id yet, so the message is generic (MPD-10696).',
+          ),
+          value: settings.showBookingToast,
+          onChanged: (value) =>
+              _vm.update(settings.copyWith(showBookingToast: value)),
+        ),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
+          child: FilledButton(
+            onPressed: _vm.isLaunching ? null : _vm.launch,
+            child: _vm.isLaunching
+                ? const SizedBox(
+                    height: 20,
+                    width: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Text('Launch Meili'),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Consistent horizontal padding for the boxed form fields.
+class _FieldPadding extends StatelessWidget {
+  const _FieldPadding({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+      child: child,
+    );
+  }
+}
+
+/// A primary-coloured section heading for the settings groups.
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader(this.title);
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 4),
+      child: Text(
+        title,
+        style: theme.textTheme.labelLarge?.copyWith(
+          color: theme.colorScheme.primary,
+        ),
+      ),
+    );
+  }
+}

--- a/meili_flutter/example/pubspec.yaml
+++ b/meili_flutter/example/pubspec.yaml
@@ -9,21 +9,13 @@ environment:
 dependencies:
     flutter:
         sdk: flutter
-    meili_flutter:
-        # When depending on this package from a real application you should use:
-        #   meili_flutter: ^x.y.z
-        # See https://dart.dev/tools/pub/dependencies#version-constraints
-        # The example app is bundled with the plugin so we use a path dependency on
-        # the parent directory to use the current plugin's version.
-        path: ../
-
-dependency_overrides:
-    meili_flutter_android:
-        path: ../../meili_flutter_android
-    meili_flutter_ios:
-        path: ../../meili_flutter_ios
-    meili_flutter_platform_interface:
-        path: ../../meili_flutter_platform_interface
+    # Published plugin — used for release / Play Store builds (resolved from
+    # pub.dev). For local development, pubspec_overrides.yaml redirects this and
+    # the federated platform packages to the in-repo source, so day-to-day
+    # `flutter run` builds against local changes. Bump this to the version you
+    # published before building against pub.dev (see scripts/build_published.sh).
+    meili_flutter: ^0.3.1-beta.4
+    shared_preferences: ^2.3.2
 
 dev_dependencies:
     flutter_driver:

--- a/meili_flutter/example/pubspec_overrides.yaml
+++ b/meili_flutter/example/pubspec_overrides.yaml
@@ -1,0 +1,17 @@
+# Local development overrides.
+#
+# While this file is present, `flutter pub get` builds the example against the
+# in-repo plugin source instead of the published `meili_flutter` declared in
+# pubspec.yaml — so local changes are picked up by `flutter run`/`flutter test`.
+#
+# To build against the PUBLISHED plugin (e.g. a Play Store release), sideline
+# this file first — `scripts/build_published.sh` does that automatically.
+dependency_overrides:
+  meili_flutter:
+    path: ../
+  meili_flutter_android:
+    path: ../../meili_flutter_android
+  meili_flutter_ios:
+    path: ../../meili_flutter_ios
+  meili_flutter_platform_interface:
+    path: ../../meili_flutter_platform_interface

--- a/meili_flutter/example/scripts/build_published.sh
+++ b/meili_flutter/example/scripts/build_published.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# Build the example app against the PUBLISHED meili_flutter from pub.dev
+# (i.e. with the local path overrides disabled), for a Play Store release.
+#
+# Day-to-day local development needs nothing — pubspec_overrides.yaml makes
+# `flutter run` use the in-repo plugin source by default. This script is only
+# for producing a release artifact that consumes the published plugin.
+#
+# Usage:
+#   scripts/build_published.sh                 # release App Bundle (.aab)
+#   scripts/build_published.sh apk             # release APK instead
+#   scripts/build_published.sh appbundle --no-tree-shake-icons
+#
+# Requires MEILI_GITHUB_USERNAME / MEILI_GITHUB_TOKEN in the environment (the
+# native Android SDK is pulled from GitHub Packages).
+set -euo pipefail
+
+cd "$(dirname "$0")/.."   # → example/
+
+overrides="pubspec_overrides.yaml"
+backup="pubspec_overrides.yaml.localdev"
+
+target="${1:-appbundle}"
+if [ "$#" -gt 0 ]; then shift; fi
+
+restore() {
+  if [ -f "$backup" ]; then
+    mv -f "$backup" "$overrides"
+    # Reset the lockfile back to local-dev mode so the next `flutter run` is
+    # unaffected. Non-fatal if it fails.
+    flutter pub get >/dev/null 2>&1 || true
+    echo "Restored local path overrides."
+  fi
+}
+trap restore EXIT
+
+if [ -f "$overrides" ]; then
+  mv -f "$overrides" "$backup"
+  echo "Disabled local path overrides — resolving meili_flutter from pub.dev."
+fi
+
+flutter pub get
+flutter build "$target" --release "$@"

--- a/meili_flutter/example/test/events_panel_test.dart
+++ b/meili_flutter/example/test/events_panel_test.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:meili_flutter/meili_flutter.dart';
 import 'package:meili_flutter_example/events_view_model.dart';
@@ -14,8 +14,8 @@ void main() {
     addTearDown(viewModel.dispose);
 
     await tester.pumpWidget(
-      CupertinoApp(
-        home: CupertinoPageScaffold(child: EventsPanel(viewModel: viewModel)),
+      MaterialApp(
+        home: Scaffold(body: EventsPanel(viewModel: viewModel)),
       ),
     );
 

--- a/meili_flutter/example/test/launch_settings_test.dart
+++ b/meili_flutter/example/test/launch_settings_test.dart
@@ -1,0 +1,138 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meili_flutter/meili_flutter.dart';
+import 'package:meili_flutter_example/launch_view_model.dart';
+import 'package:meili_flutter_example/meili_settings.dart';
+import 'package:meili_flutter_example/settings_repository.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('MeiliSettings', () {
+    test('defaults match the iOS Sample App', () {
+      const settings = MeiliSettings();
+      expect(settings.ptid, '100.9');
+      expect(settings.env, MeiliEnv.dev);
+      expect(settings.flow, FlowType.direct);
+      expect(settings.overrideCurrency, isFalse);
+      expect(settings.currency, 'EUR');
+      expect(settings.showBookingToast, isFalse);
+    });
+
+    test('toMeiliParams maps core fields and omits empty extras', () {
+      const settings = MeiliSettings(env: MeiliEnv.prod);
+      final params = settings.toMeiliParams();
+      expect(params.ptid, '100.9');
+      expect(params.env, 'prod');
+      expect(params.flow, FlowType.direct);
+      expect(params.availParams, isNull);
+      expect(params.additionalParams, isNull);
+    });
+
+    test('toMeiliParams includes booking + currency when set', () {
+      const settings = MeiliSettings(
+        flow: FlowType.bookingManager,
+        overrideCurrency: true,
+        currency: 'USD',
+        confirmationId: 'ABC123',
+        lastName: 'Doe',
+        prefillOnly: true,
+      );
+      final params = settings.toMeiliParams();
+      expect(params.flow, FlowType.bookingManager);
+      expect(params.availParams?.currencyCode, 'USD');
+      expect(params.additionalParams?.confirmationId, 'ABC123');
+      expect(params.additionalParams?.lastName, 'Doe');
+      expect(params.additionalParams?.prefillOnly, isTrue);
+    });
+
+    test('round-trips through JSON', () {
+      const settings = MeiliSettings(
+        ptid: '42',
+        env: MeiliEnv.uat,
+        flow: FlowType.bookingManager,
+        overrideCurrency: true,
+        currency: 'GBP',
+        confirmationId: 'X1',
+        lastName: 'Smith',
+        prefillOnly: true,
+        showBookingToast: true,
+      );
+      final restored = MeiliSettings.fromJson(settings.toJson());
+      expect(restored.toJson(), settings.toJson());
+    });
+  });
+
+  group('SettingsRepository', () {
+    test('returns defaults when nothing is stored', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      final repository = SettingsRepository(
+        await SharedPreferences.getInstance(),
+      );
+      expect(repository.load().toJson(), const MeiliSettings().toJson());
+    });
+
+    test('persists and reloads settings', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      final repository = SettingsRepository(
+        await SharedPreferences.getInstance(),
+      );
+      const settings = MeiliSettings(ptid: '7', env: MeiliEnv.prod);
+      await repository.save(settings);
+      expect(repository.load().toJson(), settings.toJson());
+    });
+  });
+
+  group('LaunchViewModel', () {
+    late SettingsRepository repository;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      repository = SettingsRepository(await SharedPreferences.getInstance());
+    });
+
+    test('update persists and resetToDefaults restores', () {
+      final events = StreamController<MeiliEvent>.broadcast();
+      addTearDown(events.close);
+      final viewModel = LaunchViewModel(
+        repository: repository,
+        events: events.stream,
+      );
+      addTearDown(viewModel.dispose);
+
+      viewModel.update(const MeiliSettings(ptid: '999'));
+      expect(viewModel.settings.ptid, '999');
+      expect(repository.load().ptid, '999');
+
+      viewModel.resetToDefaults();
+      expect(viewModel.settings.ptid, '100.9');
+    });
+
+    test('emits a booking toast only when enabled', () async {
+      final events = StreamController<MeiliEvent>.broadcast();
+      addTearDown(events.close);
+      final viewModel = LaunchViewModel(
+        repository: repository,
+        events: events.stream,
+      );
+      addTearDown(viewModel.dispose);
+
+      final toasts = <String>[];
+      final subscription = viewModel.toasts.listen(toasts.add);
+      addTearDown(subscription.cancel);
+
+      // Disabled by default: no toast.
+      events.add(const MeiliBookingFlowEnded());
+      await Future<void>.delayed(Duration.zero);
+      expect(toasts, isEmpty);
+
+      // Enabled: toast emitted.
+      viewModel.update(const MeiliSettings(showBookingToast: true));
+      events.add(const MeiliBookingFlowEnded());
+      await Future<void>.delayed(Duration.zero);
+      expect(toasts, <String>['Booking flow ended']);
+    });
+  });
+}

--- a/meili_flutter/example/test/launch_view_test.dart
+++ b/meili_flutter/example/test/launch_view_test.dart
@@ -1,0 +1,106 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meili_flutter/meili_flutter.dart';
+import 'package:meili_flutter_example/launch_view_model.dart';
+import 'package:meili_flutter_example/settings_repository.dart';
+import 'package:meili_flutter_example/widgets/launch_view.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Future<LaunchViewModel> buildViewModel(
+    StreamController<MeiliEvent> events,
+  ) async {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    final repository =
+        SettingsRepository(await SharedPreferences.getInstance());
+    return LaunchViewModel(repository: repository, events: events.stream);
+  }
+
+  testWidgets('renders inline settings and reveals the currency field',
+      (tester) async {
+    tester.view.physicalSize = const Size(1200, 2400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final events = StreamController<MeiliEvent>.broadcast();
+    addTearDown(events.close);
+    final viewModel = await buildViewModel(events);
+    addTearDown(viewModel.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(home: LaunchView(viewModel: viewModel)),
+    );
+
+    // Settings and the launch button share the one screen.
+    expect(find.text('PTID'), findsOneWidget);
+    expect(find.text('Launch Meili'), findsOneWidget);
+
+    // Booking Manager fields are hidden for the default Direct flow, so only
+    // PTID shows; enabling currency override adds the Currency field.
+    expect(find.byType(TextField), findsNWidgets(1));
+    viewModel.update(viewModel.settings.copyWith(overrideCurrency: true));
+    await tester.pump();
+    expect(find.byType(TextField), findsNWidgets(2));
+  });
+
+  testWidgets('Manage My Booking shows only for the Booking Manager flow',
+      (tester) async {
+    tester.view.physicalSize = const Size(1200, 2400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final events = StreamController<MeiliEvent>.broadcast();
+    addTearDown(events.close);
+    final viewModel = await buildViewModel(events);
+    addTearDown(viewModel.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(home: LaunchView(viewModel: viewModel)),
+    );
+
+    // Hidden for the default Direct flow.
+    expect(find.text('Manage My Booking'), findsNothing);
+    expect(find.text('Confirmation Id'), findsNothing);
+
+    viewModel.update(
+      viewModel.settings.copyWith(flow: FlowType.bookingManager),
+    );
+    await tester.pump();
+
+    expect(find.text('Manage My Booking'), findsOneWidget);
+    expect(find.text('Confirmation Id'), findsOneWidget);
+    expect(find.text('Last Name'), findsOneWidget);
+  });
+
+  testWidgets('Reset restores the default PTID in the text field',
+      (tester) async {
+    tester.view.physicalSize = const Size(1200, 2400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final events = StreamController<MeiliEvent>.broadcast();
+    addTearDown(events.close);
+    final viewModel = await buildViewModel(events);
+    addTearDown(viewModel.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(home: LaunchView(viewModel: viewModel)),
+    );
+
+    await tester.enterText(find.byType(TextField).first, '55');
+    await tester.pump();
+    expect(viewModel.settings.ptid, '55');
+
+    await tester.tap(find.text('Reset'));
+    await tester.pump();
+    expect(viewModel.settings.ptid, '100.9');
+    expect(find.text('100.9'), findsWidgets);
+  });
+}


### PR DESCRIPTION
## Summary

Brings the Flutter example app to parity with the iOS Sample App's tester settings ([MPD-10696](https://meili.atlassian.net/browse/MPD-10696)). Settings are **inline on the launch screen** (tweak, then launch — no separate page), built with Material widgets.

Configurable inline:
- **PTID**, **Environment** (dev/uat/preProd/prod), **Flow** (Direct / Booking Manager)
- **Override currency** + currency
- **Manage My Booking** (Confirmation Id, Last Name, Prefill only) — shown **only** for the Booking Manager flow
- **Show booking toast** (SnackBar on `MeiliBookingFlowEnded`)
- **Reset to defaults**

All persisted via `shared_preferences`. Architecture follows the repo's MVVM convention: `MeiliSettings` (model) + `SettingsRepository` + `LaunchViewModel` (ChangeNotifier); view layer is pure Material.

## Bundle id rename

Example app renamed to **`com.meili.travel.sample.flutter`** (Android `applicationId`/`namespace` + Kotlin package, iOS `PRODUCT_BUNDLE_IDENTIFIER`), display name **"Meili Sample"** — store-valid identifiers.

## Release / build setup

- **Android signing**: reads `android/key.properties` (real keystore) with a debug-keystore fallback so keyless builds still work; added `key.properties.example`. Keystore + `key.properties` are git-ignored.
- **Toolchain**: AGP 8.3→**8.7.3**, Gradle 8.4→**8.9**, NDK pinned **28.2.13676358** — fixes the R8 "Kotlin metadata 2.1.0 > max 2.0.0" crash and native symbol stripping on release builds.
- **Dual plugin source**: `pubspec.yaml` declares the published `meili_flutter`; `pubspec_overrides.yaml` (committed) redirects to local paths for day-to-day dev; `scripts/build_published.sh` sidelines the overrides to build a release artifact against the published plugin (see README).

## Known parity gaps (from MPD-10696, not regressions)

- **`connect` flow** not exposed — Flutter `FlowType` only has `direct`/`bookingManager`.
- **Locale override** omitted — `MeiliParams` exposes no locale field, so it would be a no-op.
- **Currency override** sends a full `AvailParams` with empty placeholders (Flutter `AvailParams` requires all fields).
- **Booking toast** is generic — the native `MeiliBookingFlowEnded` event carries no booking id, and events are iOS-only today.

## Test plan

- `flutter analyze` clean (very_good_analysis).
- `flutter test` — all pass (settings round-trip, `toMeiliParams` mapping, booking-toast gating, currency-field reveal, Manage-My-Booking flow visibility, events panel).
- Built + ran on Android emulator (API 35); verified the SDK launches and the installed package is `com.meili.travel.sample.flutter`.
- `flutter build appbundle --release` produces a valid, signed App Bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MPD-10696]: https://meili.atlassian.net/browse/MPD-10696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ