### PR TITLE
MPD-7173: AGP 9 compatibility + bundled Compose plugin for meili_flutter_android

### DIFF
--- a/meili_flutter/CHANGELOG.md
+++ b/meili_flutter/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.1-beta.5
+
+- Bumped `meili_flutter_android` dependency to `^0.3.0-beta.5` (Android Gradle Plugin 9 compatibility and a bundled Compose compiler plugin).
+
 ## 0.3.1-beta.4
 
 - Bumped `meili_flutter_android` dependency to `^0.3.0-beta.3`.

--- a/meili_flutter/example/pubspec.yaml
+++ b/meili_flutter/example/pubspec.yaml
@@ -1,6 +1,6 @@
 name: meili_flutter_example
 description: Demonstrates how to use the meili_flutter plugin.
-version: 0.1.0+1
+version: 0.1.0+3
 publish_to: none
 
 environment:

--- a/meili_flutter/pubspec.yaml
+++ b/meili_flutter/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
     flutter:
         sdk: flutter
     meili_flutter_platform_interface: ^0.3.0
-    meili_flutter_android: ^0.3.0-beta.3
+    meili_flutter_android: ^0.3.0-beta.5
     meili_flutter_ios: ^0.3.1-beta.3
 
 dev_dependencies:

--- a/meili_flutter_android/CHANGELOG.md
+++ b/meili_flutter_android/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.3.0-beta.5
+
+- Made the Android Gradle build compatible with Android Gradle Plugin 9 (new DSL) while keeping AGP 8 support, using property-assignment syntax (`compileSdk`, `minSdk`, `compose`, `namespace`) and the `packaging { jniLibs { pickFirsts } }` block.
+- Bundled the Compose compiler plugin (`compose-compiler-gradle-plugin`) so host apps no longer need to declare `org.jetbrains.kotlin.plugin.compose` themselves.
+- Stopped pinning the Android Gradle Plugin in the plugin buildscript; it is now inherited from the host app, which avoids AGP version conflicts on AGP 9 hosts.
+
 ## 0.3.0-beta.3
 
 - Updated Android SDK dependency to 1.6.1.

--- a/meili_flutter_android/android/build.gradle
+++ b/meili_flutter_android/android/build.gradle
@@ -9,8 +9,8 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.3.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "org.jetbrains.kotlin:compose-compiler-gradle-plugin:$kotlin_version"
     }
 }
 
@@ -33,11 +33,9 @@ apply plugin: 'kotlin-android'
 apply plugin: 'org.jetbrains.kotlin.plugin.compose'
 
 android {
-    if (project.android.hasProperty("namespace")) {
-        namespace 'com.flutter.meili'
-    }
+    namespace = "com.flutter.meili"
 
-    compileSdk 35
+    compileSdk = 35
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -54,16 +52,17 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 27
+        minSdk = 27
     }
 
     buildFeatures {
-        compose true
+        compose = true
     }
 
-    packagingOptions {
-        pickFirst "**/libc++_shared.so"
-        pickFirst "**/libfbjni.so"
+    packaging {
+        jniLibs {
+            pickFirsts += ["**/libc++_shared.so", "**/libfbjni.so"]
+        }
     }
 
     testOptions {


### PR DESCRIPTION
## What
Makes the Android side of the Flutter plugin build on apps using **Android Gradle Plugin 9** (while keeping AGP 8 working), and removes the dependency on the host app declaring the Kotlin Compose plugin.

### Changes (`meili_flutter_android/android/build.gradle`)
- Drop the pinned AGP classpath from the plugin `buildscript` so it inherits the host app's AGP. AGP is a single, build-wide version, so pinning it in the plugin conflicts with hosts on AGP 9.
- Bundle the Compose compiler plugin (`compose-compiler-gradle-plugin`) so host apps no longer need to declare `org.jetbrains.kotlin.plugin.compose` themselves.
- Convert the `android {}` block to AGP 9 new-DSL syntax (`compileSdk`, `minSdk`, `compose`, `namespace`, `packaging { jniLibs }`), which also works on AGP 8.

### Why
A freshly created Flutter app (newest Flutter → AGP 9 + Gradle 9.1 + new DSL) failed to build the plugin two ways:
- `Plugin with id 'org.jetbrains.kotlin.plugin.compose' not found`
- `does not specify compileSdk` / NullPointerException under AGP 9

### Version bumps (pre-release)
- `meili_flutter_android` `0.3.0-beta.4` → `0.3.0-beta.5`
- `meili_flutter` `0.3.1-beta.4` → `0.3.1-beta.5` (android dependency tightened to `^0.3.0-beta.5`)
- `meili_flutter_ios` and `meili_flutter_platform_interface` unchanged (no code change)
- Also bumps the example app version (`0.1.0+1` → `0.1.0+3`, `publish_to: none`)

### Testing
Built and ran the example app on **AGP 8.7.3 / Gradle 8.9** (Android 15 emulator) against this source: builds, installs, launches, and the native Meili Direct UI renders at runtime, coexisting with the example's own Compose plugin declaration.

> [!WARNING]
> Not yet validated against an AGP 9 host build. Recommend a smoke build on an AGP 9 app before publishing this pre-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
