### PR TITLE
MPD-7173: resolve the Android SDK from the public Maven repo (no credentials)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,29 +34,16 @@ flutter pub get
 
 ### Android setup
 
-The Android SDK is hosted on GitHub Packages. Add the Maven repository with credentials to your **project-level** `android/build.gradle`:
+The Android SDK is served from a public Maven repository over GitHub Pages, so **no credentials are required**. Add the repository to your **project-level** `android/build.gradle`:
 
 ```groovy
 allprojects {
     repositories {
         google()
         mavenCentral()
-        maven {
-            url = uri("https://maven.pkg.github.com/meili-travel-tech/ux-native-android-sdk")
-            credentials {
-                username = System.getenv("MEILI_GITHUB_USERNAME") ?: ""
-                password = System.getenv("MEILI_GITHUB_TOKEN") ?: ""
-            }
-        }
+        maven { url = uri("https://meili-travel-tech.github.io/ux-native-android/") }
     }
 }
-```
-
-Set environment variables (add to `~/.zshrc` or `~/.bashrc`):
-
-```bash
-export MEILI_GITHUB_USERNAME=your-github-username
-export MEILI_GITHUB_TOKEN=your-github-pat-with-read-packages-scope
 ```
 
 ### iOS setup

--- a/meili_flutter/README.md
+++ b/meili_flutter/README.md
@@ -42,52 +42,21 @@ This resolves the federated sub-packages automatically — you do not need to ad
 
 ## 2. Android setup
 
-### 2.1 GitHub credentials
+### 2.1 Declare the Maven repository
 
-The Android SDK is hosted on a private GitHub Packages repo. Set these environment variables before building:
-
-```bash
-export MEILI_GITHUB_USERNAME="your-github-username"
-export MEILI_GITHUB_TOKEN="ghp_xxxxxxxxxxxxxxxxxxxx"
-```
-
-**Where to put them:**
-- CLI builds (`flutter run` in Terminal): append to `~/.zshrc`
-- IDE / GUI app builds (Android Studio, VS Code launched from Finder): append to `~/.zshenv` — GUI apps on macOS don't always source `~/.zshrc`
-
-After editing, reload with `source ~/.zshenv` or open a new terminal.
-
-**Verifying:**
-```bash
-echo "${MEILI_GITHUB_USERNAME:-NOT_SET}"
-[ -n "$MEILI_GITHUB_TOKEN" ] && echo "TOKEN_SET" || echo "TOKEN_NOT_SET"
-```
-
-**Failure mode:** if credentials are missing you will see:
-```
-Could not resolve meili.travel:ux-native-android-sdk:...
-  > Received status code 401 from server: Unauthorized
-```
-
-### 2.2 `android/build.gradle.kts` — declare the Maven repo
+The Android SDK is served from a public Maven repository over GitHub Pages, so **no credentials are required**. Add it to your project-level `android/build.gradle.kts`:
 
 ```kotlin
 allprojects {
     repositories {
         google()
         mavenCentral()
-        maven {
-            url = uri("https://maven.pkg.github.com/meili-travel-tech/ux-native-android-sdk")
-            credentials {
-                username = System.getenv("MEILI_GITHUB_USERNAME") ?: ""
-                password = System.getenv("MEILI_GITHUB_TOKEN") ?: ""
-            }
-        }
+        maven { url = uri("https://meili-travel-tech.github.io/ux-native-android/") }
     }
 }
 ```
 
-### 2.3 `android/app/build.gradle.kts` — NDK + minSdk
+### 2.2 `android/app/build.gradle.kts` — NDK + minSdk
 
 ```kotlin
 android {
@@ -101,7 +70,7 @@ android {
 - `ndkVersion` must be pinned exactly — using `flutter.ndkVersion` may cause a linker error.
 - `minSdk = 27` is required by the Meili Android SDK.
 
-### 2.4 `android/settings.gradle.kts` — Kotlin Compose plugin
+### 2.3 `android/settings.gradle.kts` — Kotlin Compose plugin
 
 ```kotlin
 plugins {
@@ -112,7 +81,7 @@ plugins {
 }
 ```
 
-### 2.5 `MainActivity.kt`
+### 2.4 `MainActivity.kt`
 
 ```kotlin
 import io.flutter.embedding.android.FlutterFragmentActivity
@@ -219,8 +188,7 @@ await Meili.openMeiliView(MeiliParams(
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
-| `401 Unauthorized` resolving Maven dep | `MEILI_GITHUB_TOKEN` missing or lacks `read:packages` scope | Re-create PAT with `read:packages`, export, restart shell. |
-| `Could not find ... .aar` during Gradle | Maven repo URL or token missing | Check `build.gradle.kts` repo block and env vars. |
+| `Could not find ... .aar` during Gradle | Maven repo URL missing, or the version isn't published yet | Check the `build.gradle.kts` repo block points to the public Pages URL and that the version exists. |
 | `Unable to find a specification for MeiliSDK` | Missing `source` line in Podfile | Add the private spec repo URL. |
 | `pod install` hangs on first run | First-time SSH clone of spec repo | Confirm SSH key: `ssh -T git@github.com`. |
 | `IllegalStateException ... requires FragmentActivity` | `MainActivity` still extends `FlutterActivity` | Change to `FlutterFragmentActivity`. |

--- a/meili_flutter/example/android/build.gradle
+++ b/meili_flutter/example/android/build.gradle
@@ -9,11 +9,7 @@ subprojects {
 allprojects {
     repositories {
         maven {
-            url = uri("https://maven.pkg.github.com/meili-travel-tech/ux-native-android-sdk")
-            credentials {
-                username = System.getenv("MEILI_GITHUB_USERNAME") ?: ""
-                password = System.getenv("MEILI_GITHUB_TOKEN") ?: ""
-            }
+            url = uri("https://meili-travel-tech.github.io/ux-native-android/")
         }
     }
 }

--- a/meili_flutter_android/CHANGELOG.md
+++ b/meili_flutter_android/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Made the Android Gradle build compatible with Android Gradle Plugin 9 (new DSL) while keeping AGP 8 support, using property-assignment syntax (`compileSdk`, `minSdk`, `compose`, `namespace`) and the `packaging { jniLibs { pickFirsts } }` block.
 - Bundled the Compose compiler plugin (`compose-compiler-gradle-plugin`) so host apps no longer need to declare `org.jetbrains.kotlin.plugin.compose` themselves.
 - Stopped pinning the Android Gradle Plugin in the plugin buildscript; it is now inherited from the host app, which avoids AGP version conflicts on AGP 9 hosts.
+- Resolve the Meili Android SDK from the public GitHub Pages Maven repository (`https://meili-travel-tech.github.io/ux-native-android/`); host apps no longer need GitHub Packages credentials (`MEILI_GITHUB_USERNAME` / `MEILI_GITHUB_TOKEN`).
+- Updated the Meili Android SDK dependency to 1.6.8.
 
 ## 0.3.0-beta.3
 

--- a/meili_flutter_android/android/build.gradle
+++ b/meili_flutter_android/android/build.gradle
@@ -19,11 +19,7 @@ allprojects {
         google()
         mavenCentral()
         maven {
-            url = uri("https://maven.pkg.github.com/meili-travel-tech/ux-native-android-sdk")
-            credentials {
-                username = System.getenv("MEILI_GITHUB_USERNAME") ?: ""
-                password = System.getenv("MEILI_GITHUB_TOKEN") ?: ""
-            }
+            url = uri("https://meili-travel-tech.github.io/ux-native-android/")
         }
     }
 }
@@ -79,7 +75,7 @@ android {
 }
 
 dependencies {
-    implementation "meili.travel:ux-native-android-sdk:1.6.4"
+    implementation "meili.travel:ux-native-android-sdk:1.6.8"
 
     implementation 'androidx.activity:activity-compose:1.9.2'
     implementation 'androidx.compose.ui:ui:1.7.2'


### PR DESCRIPTION
## What
Switches the Flutter plugin's Android side to consume the Meili Android SDK from the **public GitHub Pages Maven repository** (`https://meili-travel-tech.github.io/ux-native-android/`) instead of GitHub Packages. Flutter Android integrators **no longer need `MEILI_GITHUB_*` credentials**.

## Changes
- `meili_flutter_android/android/build.gradle`: swap the GitHub Packages repo (with credentials) for the public Pages repo; bump `meili.travel:ux-native-android-sdk` 1.6.4 → 1.6.8.
- `meili_flutter/example/android/build.gradle`: same repo swap.
- `README.md` and `meili_flutter/README.md`: Android setup now uses the public repo with no credentials; dropped the stale 401-credentials troubleshooting row.
- `meili_flutter_android/CHANGELOG.md`: noted under the unreleased `0.3.0-beta.5` entry.

## Validation
The example app builds and runs against the public repo with the GitHub credentials unset — `ux-native-android-sdk:1.6.8` resolves from the public Pages repo with no token, and the Meili UI renders.

## Notes
- pubspec `version:` fields are left for the publish workflow to stamp (same convention as #16).
- The example's "build against the *published* plugin" path (`scripts/build_published.sh` + example README) still references `MEILI_GITHUB_*`; intentional until a plugin version built on this change is published, after which it can be de-credentialed too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
