### PR TITLE
MPD-7173: fix publish workflow for federated monorepo layout

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -83,16 +83,26 @@ jobs:
 
             - name: Install dependencies
               run: |
-                  flutter pub get
-                  cd meili_flutter/example && flutter pub get || true
-                  cd ../android && flutter pub get || true
-                  cd ../ios && flutter pub get || true
+                  for pkg in meili_flutter_platform_interface meili_flutter_android meili_flutter_ios meili_flutter meili_flutter/example; do
+                    echo "flutter pub get in $pkg"
+                    (cd "$pkg" && flutter pub get)
+                  done
 
             - name: Verify package
               run: |
-                  flutter analyze
-                  flutter test
-                  dart format --set-exit-if-changed .
+                  for pkg in meili_flutter_platform_interface meili_flutter_android meili_flutter_ios meili_flutter; do
+                    echo "flutter analyze in $pkg"
+                    (cd "$pkg" && flutter analyze --no-fatal-infos)
+                    if [ -d "$pkg/test" ]; then
+                      echo "flutter test in $pkg"
+                      (cd "$pkg" && flutter test)
+                    fi
+                  done
+                  dart format --set-exit-if-changed \
+                    meili_flutter_platform_interface \
+                    meili_flutter_android \
+                    meili_flutter_ios \
+                    meili_flutter
 
             - name: Setup Pub Credentials
               env:


### PR DESCRIPTION
## Summary
- Fix the `Publish to Pub.dev` workflow failing with "Expected to find project root in current working directory" by running `flutter pub get`, `flutter analyze`, and `flutter test` in each package directory instead of the repo root.
- Scope `dart format --set-exit-if-changed` to the federated package directories.
- Use `flutter analyze --no-fatal-infos` so pre-existing info-level lints do not block releases.

## Test plan
- [ ] Merge to `main`
- [ ] Re-run the failed `v0.3.1-beta.7` release workflow (or trigger `Publish to Pub.dev` via workflow dispatch) and confirm the Install dependencies and Verify package steps pass


Made with [Cursor](https://cursor.com)