### PR TITLE
MPD-7173: clearer error when the Flutter host is not a ComponentActivity

### DIFF
--- a/meili_flutter_android/CHANGELOG.md
+++ b/meili_flutter_android/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Stopped pinning the Android Gradle Plugin in the plugin buildscript; it is now inherited from the host app, which avoids AGP version conflicts on AGP 9 hosts.
 - Resolve the Meili Android SDK from the public GitHub Pages Maven repository (`https://meili-travel-tech.github.io/ux-native-android/`); host apps no longer need GitHub Packages credentials (`MEILI_GITHUB_USERNAME` / `MEILI_GITHUB_TOKEN`).
 - Updated the Meili Android SDK dependency to 1.6.8.
+- Fail with a clear message when the host `MainActivity` is not a `ComponentActivity` (it must extend `FlutterFragmentActivity`) instead of a generic "Activity not available" error, and log a warning at activity-attach time.
 
 ## 0.3.0-beta.3
 

--- a/meili_flutter_android/android/src/main/kotlin/com/flutter/meili/MeiliFlutterPlugin.kt
+++ b/meili_flutter_android/android/src/main/kotlin/com/flutter/meili/MeiliFlutterPlugin.kt
@@ -1,5 +1,7 @@
 package com.flutter.meili
 
+import android.app.Activity
+import android.util.Log
 import androidx.activity.ComponentActivity
 import com.meili.travel.api.AvailParams
 import com.meili.travel.api.MeiliActivity
@@ -18,6 +20,7 @@ class MeiliFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     private lateinit var channel: MethodChannel
     private lateinit var eventChannel: EventChannel
     private var activity: ComponentActivity? = null
+    private var rawActivity: Activity? = null
     private var eventSink: EventChannel.EventSink? = null
 
     override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
@@ -44,7 +47,14 @@ class MeiliFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         when (call.method) {
             "openMeiliViewController" -> {
                 val act = activity ?: run {
-                    result.error("NO_ACTIVITY", "Activity not available", null)
+                    val message = if (rawActivity != null) {
+                        "Your MainActivity must extend FlutterFragmentActivity. The Meili plugin needs " +
+                            "an androidx ComponentActivity host, but the attached activity " +
+                            "(${rawActivity?.javaClass?.name}) is not one."
+                    } else {
+                        "No Android Activity is attached to the Flutter engine."
+                    }
+                    result.error("NO_ACTIVITY", message, null)
                     return
                 }
                 @Suppress("UNCHECKED_CAST")
@@ -80,18 +90,35 @@ class MeiliFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     }
 
     override fun onAttachedToActivity(binding: ActivityPluginBinding) {
-        activity = binding.activity as? ComponentActivity
+        bindActivity(binding)
     }
 
     override fun onDetachedFromActivityForConfigChanges() {
-        activity = null
+        clearActivity()
     }
 
     override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
-        activity = binding.activity as? ComponentActivity
+        bindActivity(binding)
     }
 
     override fun onDetachedFromActivity() {
+        clearActivity()
+    }
+
+    private fun bindActivity(binding: ActivityPluginBinding) {
+        rawActivity = binding.activity
+        activity = binding.activity as? ComponentActivity
+        if (activity == null) {
+            Log.w(
+                "MeiliFlutterPlugin",
+                "Host activity ${binding.activity.javaClass.name} is not a ComponentActivity; " +
+                    "MainActivity must extend FlutterFragmentActivity for the Meili plugin to work.",
+            )
+        }
+    }
+
+    private fun clearActivity() {
         activity = null
+        rawActivity = null
     }
 }


### PR DESCRIPTION
## What
Turns the cryptic `NO_ACTIVITY` error into an actionable one. The Android plugin requires the host `MainActivity` to be an androidx `ComponentActivity` (i.e. extend `FlutterFragmentActivity`). With the default `FlutterActivity`, the activity cast silently nulled and `openMeiliView` failed with `PlatformException(NO_ACTIVITY, Activity not available)` — with no hint at the real cause.

## Changes (`meili_flutter_android`)
- Track the raw attached activity. When it is not a `ComponentActivity`, `openMeiliView` now returns a `NO_ACTIVITY` error that says *"Your MainActivity must extend FlutterFragmentActivity…"* and names the offending activity class.
- Log a warning at activity-attach time so the misconfiguration shows up in logcat immediately.

## Why
A fresh `flutter create` app's `MainActivity` extends `FlutterActivity`, which is not an androidx `ComponentActivity`, so integrators hit the unhelpful error. The installation docs are being updated in parallel to require `FlutterFragmentActivity`.

## Note
This keeps the `FlutterFragmentActivity` requirement (Option A). Relaxing the modal flow to also accept the default `FlutterActivity` (Option B) remains possible later if we get complaints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
