### PR TITLE
MPD-7173: align native SDK pins with stable releases (iOS SwiftPM 1.7.0)

### DIFF
--- a/meili_flutter_android/CHANGELOG.md
+++ b/meili_flutter_android/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.4.0
 
-- Stable release. Updated Meili Android SDK dependency to 1.7.0 (via public Maven repository).
+- Stable release. Updated Meili Android SDK dependency to 1.6.9 (via public Maven repository).
 
 ## 0.3.0-beta.5
 

--- a/meili_flutter_ios/CHANGELOG.md
+++ b/meili_flutter_ios/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.1
+
+- Point the SwiftPM `Package.swift` at the stable `ux-native-ios` 1.7.0 (was the 1.6.3 alpha), aligning the SwiftPM channel with the CocoaPods podspec.
+
 ## 0.4.0
 
 - Stable release. Bumped `MeiliSDK` to `1.7.0`.

--- a/meili_flutter_ios/ios/meili_flutter_ios/Package.swift
+++ b/meili_flutter_ios/ios/meili_flutter_ios/Package.swift
@@ -14,10 +14,9 @@ let package = Package(
         // third-party SDKs (Stripe, Evervault, HorizonCalendar, Shimmer,
         // PhoneNumberKit, SwiftUIPager), so nothing else is declared here.
         //
-        // `exact:` (not `from:`) because only pre-release tags exist today
-        // (1.6.3-alpha.N); SwiftPM excludes pre-releases from `from:` ranges.
-        // Switch to `from: "1.6.0"` once a stable 1.6.x ships.
-        .package(url: "https://github.com/meili-travel-tech/ux-native-ios", exact: "1.6.3-alpha.10")
+        // `from:` tracks the latest 1.x stable. Keep this aligned with the
+        // CocoaPods channel (meili_flutter_ios.podspec).
+        .package(url: "https://github.com/meili-travel-tech/ux-native-ios", from: "1.7.0")
     ],
     targets: [
         .target(

--- a/meili_flutter_ios/pubspec.yaml
+++ b/meili_flutter_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: meili_flutter_ios
 description: iOS implementation of the meili_flutter plugin
-version: 0.4.0
+version: 0.4.1
 
 homepage: https://github.com/meili-travel-tech/flutter_meili
 


### PR DESCRIPTION
## What
Aligns the Flutter plugin's native dependency pins with the stable SDK releases.

## Fixes
1. **iOS SwiftPM was stale.** `meili_flutter_ios/ios/meili_flutter_ios/Package.swift` pinned `ux-native-ios` at `exact: "1.6.3-alpha.10"`, while the CocoaPods podspec was already at `MeiliSDK 1.7.0`. SwiftPM-mode Flutter apps were therefore pulling the old alpha iOS SDK. Now `from: "1.7.0"`, matching the podspec.
2. **Android changelog typo.** `meili_flutter_android/CHANGELOG.md` 0.4.0 claimed the SDK dependency was bumped to `1.7.0`; the actual pin is `1.6.9` (Android is on the 1.6.x line). Corrected.

## Ships when
The iOS fix reaches consumers only once `meili_flutter_ios` is republished (a `0.4.1` patch) — I added the `0.4.1` changelog entry for that. No code or API change, just the dependency pin + changelogs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
