### PR TITLE
Point example app at published meili_flutter 0.4.1

### DIFF
--- a/meili_flutter/example/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/meili_flutter/example/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/meili-travel-tech/ux-native-ios",
       "state" : {
-        "revision" : "faf110c8b9ebded0c2f8c40ae170568a1d18b2ee",
-        "version" : "1.6.3-alpha.10"
+        "revision" : "d610e7be685fbeefcfbd641b96c4866fe3a7a138",
+        "version" : "1.7.0"
       }
     }
   ],

--- a/meili_flutter/example/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/meili_flutter/example/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/meili-travel-tech/ux-native-ios",
       "state" : {
-        "revision" : "faf110c8b9ebded0c2f8c40ae170568a1d18b2ee",
-        "version" : "1.6.3-alpha.10"
+        "revision" : "d610e7be685fbeefcfbd641b96c4866fe3a7a138",
+        "version" : "1.7.0"
       }
     }
   ],

--- a/meili_flutter/example/pubspec.yaml
+++ b/meili_flutter/example/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
     # the federated platform packages to the in-repo source, so day-to-day
     # `flutter run` builds against local changes. Bump this to the version you
     # published before building against pub.dev (see scripts/build_published.sh).
-    meili_flutter: ^0.3.1-beta.4
+    meili_flutter: ^0.4.1
     shared_preferences: ^2.3.2
 
 dev_dependencies:


### PR DESCRIPTION
## What

Bumps the **example app's** published-package pins so local release / Play Store builds (`scripts/build_published.sh`) resolve the latest release rather than an old beta.

- `meili_flutter` constraint: `^0.3.1-beta.4` → `^0.4.1` in [`example/pubspec.yaml`](meili_flutter/example/pubspec.yaml)
- iOS SwiftPM `Package.resolved` (both Runner workspaces): MeiliSDK `1.6.3-alpha.10` → `1.7.0`

## Why

A caret on a pre-release (`^0.3.1-beta.4`) resolves to `>=0.3.1-beta.4 <0.4.0`, so a published build silently stopped below the `0.4.x` line. The latest `meili_flutter` on pub.dev is `0.4.1`, which pulls `meili_flutter_android 0.4.0` (native `ux-native-android-sdk 1.6.9`, public GitHub Pages Maven) and `meili_flutter_ios 0.4.1`.

This only affects **published** builds — `pubspec_overrides.yaml` still redirects `meili_flutter` to the in-repo source for day-to-day `flutter run`, so this constraint is ignored locally.

## Testing

`flutter clean && scripts/build_published.sh` builds a signed release `.aab` (61.8 MB) against the published packages:
```
* meili_flutter 0.4.1        (was 0.3.1-beta.6 from path ..)
* meili_flutter_android 0.4.0
* meili_flutter_ios 0.4.1
✓ Built build/app/outputs/bundle/release/app-release.aab
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)