### PR TITLE
MPD-10311: expose verboseLogging flag (iOS-only) in Flutter API

### DIFF
--- a/meili_flutter/lib/src/widgets/meili_view.dart
+++ b/meili_flutter/lib/src/widgets/meili_view.dart
@@ -22,6 +22,7 @@ class MeiliView extends StatefulWidget {
     this.env,
     this.availParams,
     this.additionalParams,
+    this.verboseLogging = false,
     this.height,
     this.onEvent,
   });
@@ -40,6 +41,12 @@ class MeiliView extends StatefulWidget {
 
   /// Additional booking parameters.
   final AdditionalParams? additionalParams;
+
+  /// Enables verbose SDK logging (network dumps and flow-level diagnostics).
+  ///
+  /// **iOS only.** Off by default; error logs are always emitted regardless.
+  /// Has no effect on Android, which does not yet expose a logging control.
+  final bool verboseLogging;
 
   /// Fixed height for the embedded view. Defaults to [kViewDefaultHeight].
   final double? height;
@@ -85,6 +92,8 @@ class _MeiliViewState extends State<MeiliView> {
       'availParams': availParamsMap,
       'additionalParams': additionalParamsMap,
       'bookingParams': additionalParamsMap,
+      // iOS-only for now; Android ignores this key.
+      'verboseLogging': widget.verboseLogging,
     };
 
     final Widget platform;

--- a/meili_flutter_platform_interface/lib/src/model/meili_params.dart
+++ b/meili_flutter_platform_interface/lib/src/model/meili_params.dart
@@ -11,6 +11,7 @@ class MeiliParams {
     required this.env,
     this.availParams,
     this.additionalParams,
+    this.verboseLogging = false,
   });
 
   /// The ptid (possibly partner ID) for the Meili view.
@@ -28,6 +29,15 @@ class MeiliParams {
   /// The booking parameters for the Meili view.
   final AdditionalParams? additionalParams;
 
+  /// Enables verbose SDK logging (network request/response dumps and
+  /// flow-level diagnostics), emitted via Apple's unified logging under
+  /// subsystem `com.meili.travel.MeiliSDK`.
+  ///
+  /// **iOS only.** Off by default so the SDK stays quiet in your console;
+  /// error logs are always emitted regardless of this flag. Has no effect on
+  /// Android, which does not yet expose a logging control.
+  final bool verboseLogging;
+
   /// Converts the [MeiliParams] instance to a map.
   Map<String, dynamic> toMap() {
     return {
@@ -36,6 +46,7 @@ class MeiliParams {
       'env': env,
       'availParams': availParams?.toMap(),
       'additionalParams': additionalParams?.toMap(),
+      'verboseLogging': verboseLogging,
     };
   }
 }


### PR DESCRIPTION
## Summary

Exposes a `verboseLogging` flag through the Flutter API so host apps can enable the iOS SDK's verbose logging. Pairs with the native SDK change in `ux-native-ios-sdk` PR #168, which adds `MeiliParams.verboseLogging` (errors always emit; verbose levels — network dumps + flow diagnostics — only when opted in).

## Changes (Dart only)
- **`MeiliParams`** (`meili_flutter_platform_interface`): new `bool verboseLogging` (default `false`), threaded into `toMap()`. Drives the modal flow (`Meili.openMeiliView`).
- **`MeiliView`** widget (`meili_flutter`): new `verboseLogging` param (default `false`), added to `creationParams`. Drives the embedded platform-view flow.
- Both are documented **iOS-only**: off by default, errors always logged regardless, and **no effect on Android** (which doesn't yet expose a logging control and simply ignores the extra key).

```dart
Meili.openMeiliView(MeiliParams(ptid: '100.9', flow: FlowType.direct, env: 'dev', verboseLogging: true));
// or
MeiliView(ptid: '100.9', verboseLogging: true)
```

## Follow-up (intentionally not in this PR)
The iOS Swift passthrough is **blocked on the native SDK release**. The podspec pins `MeiliSDK '1.7.0'`, but `verboseLogging` only lands in a later release (via `ux-native-ios-sdk` PR #168). Adding `MeiliParams(..., verboseLogging:)` to the Swift now would fail to compile against 1.7.0. Once that SDK version is published:
1. Bump `meili_flutter_ios.podspec` `MeiliSDK` dependency.
2. Parse and forward `verboseLogging` in `MeiliFlutterPlugin.swift` (modal) and `MeiliViewFactory.swift` (embedded).

Until then the flag flows through the channel harmlessly and iOS ignores it (like Android), so the API/typing is in place with no build risk.

## Test plan
- `dart analyze` on both changed packages: no new issues (only pre-existing, unrelated `info` lints).
- Additive optional field — existing `MeiliParams` / `MeiliView` call sites compile unchanged.

## Notes
- Additive, non-breaking change to the platform-interface public model — consider a minor version bump on `meili_flutter_platform_interface` / `meili_flutter` at release time.
- Heads-up: this repo's `check-issue-key` workflow word-splits the commit subject and requires a Jira key in every token, so it flags normal messages (including existing merged commits) — pre-existing CI bug, unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
